### PR TITLE
Fix 2D default collider density mass update (v0.1.11)

### DIFF
--- a/collision/collider_set.mbt
+++ b/collision/collider_set.mbt
@@ -2955,6 +2955,35 @@ pub fn ColliderSet::colliders_with_parent(
 }
 
 ///|
+fn recompute_body_mass_properties_from_attached_colliders(
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
+  body_handle : @dynamics.RigidBodyHandle,
+) -> Unit {
+  if bodies.get_mut_internal_with_modification_tracking(body_handle)
+    is Some(body) {
+    let attached = colliders.colliders_with_parent(body_handle)
+    let mut mprops = @core.MassProperties::default()
+    for j in 0..<attached.length() {
+      let co_handle = attached[j]
+      if colliders.get(co_handle) is Some(collider) {
+        let local_pos = @core.Isometry2::new(
+          collider.local_translation,
+          @core.Rot2::from_angle(collider.local_rotation),
+        )
+        mprops = mprops.add(collider.mass_properties().transform_by(local_pos))
+      }
+    }
+    let added_mass = body.additional_mass()
+    if added_mass != 0.0F {
+      mprops = mprops.set_mass(mprops.mass + added_mass, true)
+    }
+    body.mark_local_mass_properties_changed() |> ignore
+    body.set_local_mass_properties(mprops) |> ignore
+  }
+}
+
+///|
 pub fn ColliderSet::insert_with_parent(
   self : ColliderSet,
   collider : Collider,
@@ -2970,6 +2999,9 @@ pub fn ColliderSet::insert_with_parent(
   if self.colliders[handle.id] is Some(collider_ref) {
     self.push_modified_unchecked(handle, collider_ref)
   }
+  // Match Rapier behavior: attaching a collider must immediately update the rigid-body
+  // mass properties, so impulses applied before the next pipeline step behave correctly.
+  recompute_body_mass_properties_from_attached_colliders(bodies, self, parent)
   handle
 }
 
@@ -3043,6 +3075,7 @@ pub fn ColliderSet::remove(
     return
   }
   if self.colliders[handle.id] is Some(collider) {
+    let parent = collider.parent
     // Removing a collider must invalidate the parent rigid-body mass-properties like Rapier.
     if collider.parent is Some(parent) {
       if bodies.get_mut_internal_with_modification_tracking(parent)
@@ -3057,6 +3090,9 @@ pub fn ColliderSet::remove(
     self.removed_colliders.push(handle)
     self.generations[handle.id] = self.generations[handle.id] + 1
     self.free_list.push(handle.id)
+    if parent is Some(rb) {
+      recompute_body_mass_properties_from_attached_colliders(bodies, self, rb)
+    }
   }
   islands |> ignore
 }
@@ -3115,6 +3151,7 @@ pub fn ColliderSet::set_parent(
     return
   }
   if self.colliders[handle.id] is Some(collider) {
+    let old_parent = collider.parent
     collider.parent = parent
     collider.changes = collider.changes.insert(COLLIDER_CHANGES_PARENT)
     self.colliders[handle.id] = Some(
@@ -3122,6 +3159,18 @@ pub fn ColliderSet::set_parent(
     )
     if self.colliders[handle.id] is Some(updated) {
       self.push_modified(handle, updated)
+    }
+    // Update mass properties immediately for both the old and new parent, so impulses applied
+    // before the next pipeline step behave like Rapier.
+    if old_parent is Some(old_rb) {
+      recompute_body_mass_properties_from_attached_colliders(
+        bodies, self, old_rb,
+      )
+    }
+    if parent is Some(new_rb) {
+      recompute_body_mass_properties_from_attached_colliders(
+        bodies, self, new_rb,
+      )
     }
   }
 }

--- a/dynamics/default_density_inv_mass_test.mbt
+++ b/dynamics/default_density_inv_mass_test.mbt
@@ -1,0 +1,40 @@
+// Copyright 2026 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "2d: attaching collider recomputes mass properties immediately (default density)" {
+  let bodies = RigidBodySet::new()
+  let colliders = @collision.ColliderSet::new()
+  let rb = bodies.insert(RigidBodyBuilder::dynamic().build())
+
+  // Simulate a world that already processed the initial insertion.
+  bodies.take_modified() |> ignore
+
+  // Attach a collider without calling `.density(...)` explicitly.
+  colliders.insert_with_parent(
+    @collision.ColliderBuilder::cuboid(0.5F, 0.5F).build(),
+    rb,
+    bodies,
+  )
+  |> ignore
+
+  // Mass properties should be immediately available for impulses.
+  if bodies.get(rb) is Some(body) {
+    inspect(body.inv_mass() > 0.0F, content="true")
+    body.apply_impulse(@core.Vec2::new(1.0F, 0.0F), true) |> ignore
+    inspect(body.linvel().x != 0.0F, content="true")
+  } else {
+    inspect(false, content="true")
+  }
+}

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "Milky2018/moon_rapier",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "readme": "README.md",
   "repository": "https://github.com/moonbit-community/moon_rapier",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes a 2D issue where attaching a collider could leave a dynamic body with inv_mass=0 until the next pipeline step (making apply_impulse/impulse-like APIs look ineffective).\n\nChanges:\n- Recompute parent rigid-body mass properties immediately when attaching/detaching colliders (insert_with_parent/set_parent/remove).\n- Add regression test.\n- Bump version to 0.1.11.\n\nQuality gates:\n- moon check\n- moon test --frozen