### PR TITLE
Cleanup moon check warnings for public APIs (v0.1.12)

### DIFF
--- a/collision/collider_set.mbt
+++ b/collision/collider_set.mbt
@@ -488,14 +488,44 @@ pub struct ColliderFlags {
 }
 
 ///|
+pub fn ColliderFlags::new(
+  collision_groups : @dynamics.InteractionGroups,
+  solver_groups : @dynamics.InteractionGroups,
+  active_collision_types : ActiveCollisionTypes,
+  active_hooks : ActiveHooks,
+  active_events : ActiveEvents,
+) -> ColliderFlags {
+  {
+    collision_groups,
+    solver_groups,
+    active_collision_types,
+    active_hooks,
+    active_events,
+  }
+}
+
+///|
 pub struct ColliderParent {
   handle : @dynamics.RigidBodyHandle
   pos_wrt_parent : @core.Isometry2
 }
 
 ///|
+pub fn ColliderParent::new(
+  handle : @dynamics.RigidBodyHandle,
+  pos_wrt_parent : @core.Isometry2,
+) -> ColliderParent {
+  { handle, pos_wrt_parent }
+}
+
+///|
 pub struct ColliderPosition {
   position : @core.Isometry2
+}
+
+///|
+pub fn ColliderPosition::new(position : @core.Isometry2) -> ColliderPosition {
+  { position, }
 }
 
 ///|

--- a/collision/pkg.generated.mbti
+++ b/collision/pkg.generated.mbti
@@ -508,6 +508,7 @@ pub struct ColliderFlags {
   active_hooks : ActiveHooks
   active_events : ActiveEvents
 }
+pub fn ColliderFlags::new(@dynamics.InteractionGroups, @dynamics.InteractionGroups, ActiveCollisionTypes, ActiveHooks, ActiveEvents) -> Self
 
 pub struct ColliderHandle {
   id : Int
@@ -562,10 +563,12 @@ pub struct ColliderParent {
   handle : @dynamics.RigidBodyHandle
   pos_wrt_parent : @core.Isometry2
 }
+pub fn ColliderParent::new(@dynamics.RigidBodyHandle, @core.Isometry2) -> Self
 
 pub struct ColliderPosition {
   position : @core.Isometry2
 }
+pub fn ColliderPosition::new(@core.Isometry2) -> Self
 
 pub struct ColliderSet {
   colliders : Array[Collider?]

--- a/dynamics/integration_parameters.mbt
+++ b/dynamics/integration_parameters.mbt
@@ -108,6 +108,16 @@ pub fn FrictionModel::default() -> FrictionModel {
 }
 
 ///|
+pub fn FrictionModel::simplified() -> FrictionModel {
+  FrictionModel::Simplified
+}
+
+///|
+pub fn FrictionModel::coulomb() -> FrictionModel {
+  FrictionModel::Coulomb
+}
+
+///|
 pub struct IntegrationParameters {
   mut dt : @core.Real
   mut min_ccd_dt : @core.Real

--- a/dynamics/pkg.generated.mbti
+++ b/dynamics/pkg.generated.mbti
@@ -101,7 +101,9 @@ pub enum FrictionModel {
   Simplified
   Coulomb
 }
+pub fn FrictionModel::coulomb() -> Self
 pub fn FrictionModel::default() -> Self
+pub fn FrictionModel::simplified() -> Self
 
 pub struct GenericJoint {
   mut local_frame1 : @core.Isometry2
@@ -1143,6 +1145,9 @@ pub enum RigidBodyAdditionalMassProps {
   MassProps(@core.MassProperties)
   MassProperties(@core.MassProperties)
 }
+pub fn RigidBodyAdditionalMassProps::mass(Float) -> Self
+pub fn RigidBodyAdditionalMassProps::mass_properties(@core.MassProperties) -> Self
+pub fn RigidBodyAdditionalMassProps::mass_props(@core.MassProperties) -> Self
 
 pub struct RigidBodyBuilder {
   mut position : @core.Isometry2

--- a/dynamics/rigid_body.mbt
+++ b/dynamics/rigid_body.mbt
@@ -794,6 +794,27 @@ pub enum RigidBodyAdditionalMassProps {
 }
 
 ///|
+pub fn RigidBodyAdditionalMassProps::mass(
+  mass : @core.Real,
+) -> RigidBodyAdditionalMassProps {
+  RigidBodyAdditionalMassProps::Mass(mass)
+}
+
+///|
+pub fn RigidBodyAdditionalMassProps::mass_props(
+  mass_props : @core.MassProperties,
+) -> RigidBodyAdditionalMassProps {
+  RigidBodyAdditionalMassProps::MassProps(mass_props)
+}
+
+///|
+pub fn RigidBodyAdditionalMassProps::mass_properties(
+  mass_properties : @core.MassProperties,
+) -> RigidBodyAdditionalMassProps {
+  RigidBodyAdditionalMassProps::MassProperties(mass_properties)
+}
+
+///|
 pub struct RigidBody {
   mut ids : RigidBodyIds
   position : RigidBodyPosition

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "Milky2018/moon_rapier",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "readme": "README.md",
   "repository": "https://github.com/moonbit-community/moon_rapier",
   "license": "Apache-2.0",

--- a/pipeline/physics_hooks.mbt
+++ b/pipeline/physics_hooks.mbt
@@ -23,6 +23,18 @@ pub struct PairFilterContext {
 }
 
 ///|
+pub fn PairFilterContext::new(
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
+  collider1 : @collision.ColliderHandle,
+  collider2 : @collision.ColliderHandle,
+  rigid_body1 : @dynamics.RigidBodyHandle?,
+  rigid_body2 : @dynamics.RigidBodyHandle?,
+) -> PairFilterContext {
+  { bodies, colliders, collider1, collider2, rigid_body1, rigid_body2 }
+}
+
+///|
 pub struct ContactModificationContext {
   bodies : @dynamics.RigidBodySet
   colliders : @collision.ColliderSet

--- a/pipeline/pkg.generated.mbti
+++ b/pipeline/pkg.generated.mbti
@@ -200,6 +200,7 @@ pub struct PairFilterContext {
   rigid_body1 : @dynamics.RigidBodyHandle?
   rigid_body2 : @dynamics.RigidBodyHandle?
 }
+pub fn PairFilterContext::new(@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @dynamics.RigidBodyHandle?, @dynamics.RigidBodyHandle?) -> Self
 
 pub struct PhysicsHooks {
   mut filter_contact_pair : ((@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle) -> Bool)?


### PR DESCRIPTION
Add lightweight constructors for several pub-only API items so moon check emits 0 warnings. Bump version to 0.1.12.