### PR TITLE
3DReal: add sensor collision events regression test

### DIFF
--- a/pipeline/physics_pipeline3d_real_test.mbt
+++ b/pipeline/physics_pipeline3d_real_test.mbt
@@ -228,3 +228,105 @@ test "physics_pipeline3d_real: collision events for non-sensor contacts" {
     content="true",
   )
 }
+
+///|
+test "physics_pipeline3d_real: collision events for sensor intersections" {
+  let pipeline = PhysicsPipeline3DReal::new()
+  let broad_phase = @collision.BroadPhase3D::new()
+  let narrow_phase = @collision.NarrowPhase3D::new()
+  let islands = @dynamics.IslandManager3D::new()
+  let bodies = @dynamics.RigidBodySet3D::new()
+  let colliders = @collision.ColliderSet3D::new()
+  let gravity = @core.Vec3::zero()
+  let parameters = @dynamics.IntegrationParameters::default().set_dt(
+    1.0F / 60.0F,
+  )
+  let handler = EventHandler3D::new()
+  fn has_event(
+    events : Array[@collision.CollisionEvent3D],
+    started : Bool,
+    sensor : Bool,
+    a : @collision.ColliderHandle3D,
+    b : @collision.ColliderHandle3D,
+  ) -> Bool {
+    for e in events {
+      if started {
+        if !e.started() {
+          continue
+        }
+      } else if !e.stopped() {
+        continue
+      }
+      if e.sensor() != sensor {
+        continue
+      }
+      let c1 = e.collider1()
+      let c2 = e.collider2()
+      if (c1.equals(a) && c2.equals(b)) || (c1.equals(b) && c2.equals(a)) {
+        return true
+      }
+    }
+    false
+  }
+
+  let ground = bodies.insert(
+    @dynamics.RigidBodyBuilder3D::fixed()
+    .translation(@core.Vec3::new(0.0F, -1.0F, 0.0F))
+    .build(),
+  )
+  let ground_collider = colliders.insert_with_parent(
+    @collision.ColliderBuilder3D::cuboid(10.0F, 1.0F, 10.0F).build(),
+    ground,
+    bodies,
+  )
+  let ball = bodies.insert(
+    @dynamics.RigidBodyBuilder3D::kinematic_position_based()
+    .translation(@core.Vec3::new(0.0F, 2.0F, 0.0F))
+    .build(),
+  )
+  let ball_collider = colliders.insert_with_parent(
+    @collision.ColliderBuilder3D::ball(0.5F)
+    .sensor(true)
+    .active_events(@collision.ActiveEvents::collision_events())
+    .build(),
+    ball,
+    bodies,
+  )
+
+  // Step once: no intersection, no events.
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  let ev0 = handler.take_collision_events()
+  inspect(ev0.length(), content="0")
+
+  // Move into intersection: should emit Started with sensor flags.
+  if bodies.get(ball) is Some(rb) {
+    rb.set_next_kinematic_translation(@core.Vec3::new(0.0F, 0.4F, 0.0F))
+  } else {
+    inspect(false, content="true")
+  }
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  let ev1 = handler.take_collision_events()
+  inspect(
+    has_event(ev1, true, true, ball_collider, ground_collider),
+    content="true",
+  )
+
+  // Move out of intersection: should emit Stopped with sensor flags.
+  if bodies.get(ball) is Some(rb2) {
+    rb2.set_next_kinematic_translation(@core.Vec3::new(0.0F, 2.0F, 0.0F))
+  } else {
+    inspect(false, content="true")
+  }
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  let ev2 = handler.take_collision_events()
+  inspect(
+    has_event(ev2, false, true, ball_collider, ground_collider),
+    content="true",
+  )
+}


### PR DESCRIPTION
Adds regression coverage ensuring CollisionEvent3D Started/Stopped is emitted for sensor intersections (sensor flag true), complementing existing non-sensor contact coverage.