### PR TITLE
3DReal: harden semantic parity (CCD split + event regression tests)

### DIFF
--- a/SEMANTIC_PARITY_3D_AUDIT.md
+++ b/SEMANTIC_PARITY_3D_AUDIT.md
@@ -1,0 +1,61 @@
+# 3D Semantic Parity Gap Audit (Rapier v0.32.0)
+
+This repository already tracks parity with upstream Rapier in two ways:
+
+1) **Crate-level public surface audit** for `rapier3d`/`rapier2d` default features.
+2) **Behavioral parity tests** under `rapier_full/` for representative scenes/examples.
+
+This document is the starting checklist for “3D semantic parity” work that goes beyond
+`pub`-surface coverage.
+
+## Current Baseline (as of this audit)
+
+- `python3 tools/rapier_pub_audit.py run`
+  - `rapier2d`: `missing=0` (default features)
+  - `rapier3d`: `missing=0` (default features)
+- `moon test --frozen`: all tests passing.
+
+## Gap Checklist (3D)
+
+### Collision events
+- Started/Stopped should be emitted for:
+  - **Sensor intersections** (flags indicate `sensor`).
+  - **Non-sensor contacts** (flags indicate non-sensor).
+- Events must not repeat while the interaction persists (diff-based).
+- Regression coverage:
+  - `pipeline/physics_pipeline3d_real_test.mbt`:
+    - sensor intersections Started/Stopped
+    - non-sensor contacts Started/Stopped
+    - “no repeat while persists” for both
+
+### CCD (continuous collision detection)
+- Fast-moving balls should not tunnel through thin obstacles when CCD is enabled.
+- Regression coverage:
+  - `pipeline/physics_pipeline3d_real_test.mbt`: “CCD prevents tunneling for fast balls”.
+- Implementation note:
+  - When splitting at TOI, a tiny overshoot is applied so the next step starts in a strictly
+    intersecting configuration (avoids broad-phase boundary cases on exact touching).
+
+### Narrow-phase / manifolds
+- Verify contact normal direction, penetration sign, and contact point ordering for:
+  - ball/cuboid, ball/ball, capsule/cuboid, cylinder/cuboid, halfspace/*,
+    trimesh/ball, heightfield/ball, voxels/ball.
+- Verify manifold persistence/stability where applicable (no jittery contact flipping).
+- Add focused deterministic unit tests when parity tests don’t cover a case.
+
+### Joints / multibody
+- Verify joint limits/motors and multibody IK behaviors match rapier-reference for common setups.
+- Prefer porting upstream unit tests when possible; otherwise add deterministic MoonBit tests.
+
+### Query pipeline
+- Verify ray casting, shape casting, and filtering flags match rapier-reference.
+- Add edge-case tests for filters (exclude collider/body, collision groups, sensors).
+
+## How to run
+
+```bash
+python3 tools/rapier_pub_audit.py run
+moon test --frozen
+moon test -p pipeline -f physics_pipeline3d_real_test.mbt
+```
+

--- a/pipeline/physics_pipeline3d_real.mbt
+++ b/pipeline/physics_pipeline3d_real.mbt
@@ -564,6 +564,15 @@ fn PhysicsPipeline3DReal::step_impl(
     substeps = 64
   }
   let sub_dt = dt / Float::from_int(substeps)
+  // When splitting a substep at a computed TOI, slightly overshoot the TOI so the next
+  // step begins in a strictly-intersecting configuration. This avoids missing the contact
+  // solve due to broad-phase boundary cases when the shapes are exactly touching.
+  let ccd_overlap_time = if max_speed > 1.0e-12F {
+    let dist_eps = 1.0e-4F * parameters.length_unit
+    dist_eps / max_speed
+  } else {
+    0.0F
+  }
   let sub_params = parameters.with_dt(sub_dt)
   for _ in 0..<substeps {
     // TOI-based CCD for fast moving balls.
@@ -571,12 +580,18 @@ fn PhysicsPipeline3DReal::step_impl(
       ccd_min_toi_ball_3d(bodies, colliders, sub_dt) is Some(toi) &&
       toi > 1.0e-6F &&
       toi < sub_dt {
-      let p1 = parameters.with_dt(toi)
+      let toi_step = if ccd_overlap_time > 0.0F &&
+        toi + ccd_overlap_time < sub_dt {
+        toi + ccd_overlap_time
+      } else {
+        toi
+      }
+      let p1 = parameters.with_dt(toi_step)
       PhysicsPipeline3DReal::step_impl_one(
         self, gravity, p1, islands, broad_phase, narrow_phase, bodies, colliders,
         events, rope_joints, joints,
       )
-      let rem = sub_dt - toi
+      let rem = sub_dt - toi_step
       if rem > 0.0F {
         let p2 = parameters.with_dt(rem)
         PhysicsPipeline3DReal::step_impl_one(

--- a/pipeline/physics_pipeline3d_real_test.mbt
+++ b/pipeline/physics_pipeline3d_real_test.mbt
@@ -330,3 +330,170 @@ test "physics_pipeline3d_real: collision events for sensor intersections" {
     content="true",
   )
 }
+
+///|
+test "physics_pipeline3d_real: CCD prevents tunneling for fast balls (disabled vs enabled)" {
+  fn run(ccd_enabled : Bool) -> @core.Real {
+    let pipeline = PhysicsPipeline3DReal::new()
+    let broad_phase = @collision.BroadPhase3D::new()
+    let narrow_phase = @collision.NarrowPhase3D::new()
+    let islands = @dynamics.IslandManager3D::new()
+    let bodies = @dynamics.RigidBodySet3D::new()
+    let colliders = @collision.ColliderSet3D::new()
+    let gravity = @core.Vec3::zero()
+    let parameters = @dynamics.IntegrationParameters::default().set_dt(1.0F)
+    let wall = bodies.insert(@dynamics.RigidBodyBuilder3D::fixed().build())
+    colliders.insert_with_parent(
+      @collision.ColliderBuilder3D::cuboid(0.1F, 10.0F, 10.0F).build(),
+      wall,
+      bodies,
+    )
+    |> ignore
+    let ball = bodies.insert(
+      @dynamics.RigidBodyBuilder3D::dynamic()
+      .translation(@core.Vec3::new(-10.0F, 0.0F, 0.0F))
+      .ccd_enabled(ccd_enabled)
+      .build(),
+    )
+    colliders.insert_with_parent(
+      @collision.ColliderBuilder3D::ball(1.0F).build(),
+      ball,
+      bodies,
+    )
+    |> ignore
+    if bodies.get_mut(ball) is Some(rb) {
+      rb.set_linvel(@core.Vec3::new(1000.0F, 0.0F, 0.0F))
+      rb.wake_up()
+    }
+    pipeline.step(
+      gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders,
+    )
+    if bodies.get(ball) is Some(rb2) {
+      rb2.translation().x
+    } else {
+      0.0F
+    }
+  }
+
+  let no_ccd_x = run(false)
+  inspect(no_ccd_x > 0.0F, content="true")
+  let ccd_x = run(true)
+  inspect(ccd_x < 0.0F, content="true")
+}
+
+///|
+test "physics_pipeline3d_real: collision events do not repeat while contact persists" {
+  let pipeline = PhysicsPipeline3DReal::new()
+  let broad_phase = @collision.BroadPhase3D::new()
+  let narrow_phase = @collision.NarrowPhase3D::new()
+  let islands = @dynamics.IslandManager3D::new()
+  let bodies = @dynamics.RigidBodySet3D::new()
+  let colliders = @collision.ColliderSet3D::new()
+  let gravity = @core.Vec3::zero()
+  let parameters = @dynamics.IntegrationParameters::default().set_dt(
+    1.0F / 60.0F,
+  )
+  let handler = EventHandler3D::new()
+  let ground = bodies.insert(
+    @dynamics.RigidBodyBuilder3D::fixed()
+    .translation(@core.Vec3::new(0.0F, -1.0F, 0.0F))
+    .build(),
+  )
+  colliders.insert_with_parent(
+    @collision.ColliderBuilder3D::cuboid(10.0F, 1.0F, 10.0F).build(),
+    ground,
+    bodies,
+  )
+  |> ignore
+  let ball = bodies.insert(
+    @dynamics.RigidBodyBuilder3D::kinematic_position_based()
+    .translation(@core.Vec3::new(0.0F, 2.0F, 0.0F))
+    .build(),
+  )
+  colliders.insert_with_parent(
+    @collision.ColliderBuilder3D::ball(0.5F)
+    .active_events(@collision.ActiveEvents::collision_events())
+    .build(),
+    ball,
+    bodies,
+  )
+  |> ignore
+
+  // Step into contact: expect exactly one Started.
+  if bodies.get(ball) is Some(rb) {
+    rb.set_next_kinematic_translation(@core.Vec3::new(0.0F, 0.4F, 0.0F))
+  } else {
+    inspect(false, content="true")
+  }
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  let ev1 = handler.take_collision_events()
+  inspect(ev1.length() > 0, content="true")
+
+  // Keep contact: should emit no further events.
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  let ev2 = handler.take_collision_events()
+  inspect(ev2.length(), content="0")
+}
+
+///|
+test "physics_pipeline3d_real: collision events do not repeat while sensor intersection persists" {
+  let pipeline = PhysicsPipeline3DReal::new()
+  let broad_phase = @collision.BroadPhase3D::new()
+  let narrow_phase = @collision.NarrowPhase3D::new()
+  let islands = @dynamics.IslandManager3D::new()
+  let bodies = @dynamics.RigidBodySet3D::new()
+  let colliders = @collision.ColliderSet3D::new()
+  let gravity = @core.Vec3::zero()
+  let parameters = @dynamics.IntegrationParameters::default().set_dt(
+    1.0F / 60.0F,
+  )
+  let handler = EventHandler3D::new()
+  let ground = bodies.insert(
+    @dynamics.RigidBodyBuilder3D::fixed()
+    .translation(@core.Vec3::new(0.0F, -1.0F, 0.0F))
+    .build(),
+  )
+  colliders.insert_with_parent(
+    @collision.ColliderBuilder3D::cuboid(10.0F, 1.0F, 10.0F).build(),
+    ground,
+    bodies,
+  )
+  |> ignore
+  let ball = bodies.insert(
+    @dynamics.RigidBodyBuilder3D::kinematic_position_based()
+    .translation(@core.Vec3::new(0.0F, 2.0F, 0.0F))
+    .build(),
+  )
+  colliders.insert_with_parent(
+    @collision.ColliderBuilder3D::ball(0.5F)
+    .sensor(true)
+    .active_events(@collision.ActiveEvents::collision_events())
+    .build(),
+    ball,
+    bodies,
+  )
+  |> ignore
+
+  // Step into intersection: expect exactly one Started.
+  if bodies.get(ball) is Some(rb) {
+    rb.set_next_kinematic_translation(@core.Vec3::new(0.0F, 0.4F, 0.0F))
+  } else {
+    inspect(false, content="true")
+  }
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  let ev1 = handler.take_collision_events()
+  inspect(ev1.length() > 0, content="true")
+
+  // Keep intersection: should emit no further events.
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  let ev2 = handler.take_collision_events()
+  inspect(ev2.length(), content="0")
+}


### PR DESCRIPTION
- Improve 3DReal CCD TOI splitting by applying a tiny overshoot so the next step begins in a strictly-intersecting config (avoids broad-phase boundary cases on exact touching).\n- Add/extend regression tests for 3DReal collision events (sensor+contact) and stability while persisting.\n- Add SEMANTIC_PARITY_3D_AUDIT.md checklist.