### PR TITLE
Expose IntersectionEvent stream (v0.1.13)

### DIFF
--- a/collision/bitflags_parity_test.mbt
+++ b/collision/bitflags_parity_test.mbt
@@ -16,15 +16,22 @@
 test "ActiveEvents bitflags parity helpers" {
   let a = ActiveEvents::collision_events()
   let b = ActiveEvents::contact_force_events()
+  let c = ActiveEvents::intersection_events()
   let ab = a.union(b)
+  let abc = ab.union(c)
   inspect(ab.contains(a), content="true")
   inspect(ab.contains(b), content="true")
-  inspect(ab.is_all(), content="true")
+  inspect(abc.is_all(), content="true")
   inspect(a.complement().contains(b), content="true")
   inspect(ActiveEvents::from_bits(3) is Some(_), content="true")
-  inspect(ActiveEvents::from_bits(4) is None, content="true")
+  inspect(ActiveEvents::from_bits(4) is Some(_), content="true")
+  inspect(ActiveEvents::from_bits(8) is None, content="true")
   inspect(
     ActiveEvents::from_name("COLLISION_EVENTS") is Some(_),
+    content="true",
+  )
+  inspect(
+    ActiveEvents::from_name("INTERSECTION_EVENTS") is Some(_),
     content="true",
   )
   inspect(ActiveEvents::from_name("NOPE") is None, content="true")

--- a/collision/events.mbt
+++ b/collision/events.mbt
@@ -19,6 +19,9 @@ const ACTIVE_EVENTS_COLLISION_EVENTS : Int = 1 << 0
 const ACTIVE_EVENTS_CONTACT_FORCE_EVENTS : Int = 1 << 1
 
 ///|
+const ACTIVE_EVENTS_INTERSECTION_EVENTS : Int = 1 << 2
+
+///|
 pub struct ActiveEvents {
   mut bits : Int
 }
@@ -30,7 +33,9 @@ fn ActiveEvents::new(bits : Int) -> ActiveEvents {
 
 ///|
 fn active_events_all_bits() -> Int {
-  ACTIVE_EVENTS_COLLISION_EVENTS | ACTIVE_EVENTS_CONTACT_FORCE_EVENTS
+  ACTIVE_EVENTS_COLLISION_EVENTS |
+  ACTIVE_EVENTS_CONTACT_FORCE_EVENTS |
+  ACTIVE_EVENTS_INTERSECTION_EVENTS
 }
 
 ///|
@@ -46,6 +51,11 @@ pub fn ActiveEvents::collision_events() -> ActiveEvents {
 ///|
 pub fn ActiveEvents::contact_force_events() -> ActiveEvents {
   ActiveEvents::new(ACTIVE_EVENTS_CONTACT_FORCE_EVENTS)
+}
+
+///|
+pub fn ActiveEvents::intersection_events() -> ActiveEvents {
+  ActiveEvents::new(ACTIVE_EVENTS_INTERSECTION_EVENTS)
 }
 
 ///|
@@ -135,6 +145,9 @@ pub fn ActiveEvents::iter_names(self : ActiveEvents) -> Array[String] {
   if self.contains(ActiveEvents::contact_force_events()) {
     result.push("CONTACT_FORCE_EVENTS")
   }
+  if self.contains(ActiveEvents::intersection_events()) {
+    result.push("INTERSECTION_EVENTS")
+  }
   result
 }
 
@@ -144,6 +157,8 @@ pub fn ActiveEvents::from_name(name : String) -> ActiveEvents? {
     Some(ActiveEvents::collision_events())
   } else if name == "CONTACT_FORCE_EVENTS" {
     Some(ActiveEvents::contact_force_events())
+  } else if name == "INTERSECTION_EVENTS" {
+    Some(ActiveEvents::intersection_events())
   } else {
     None
   }
@@ -247,6 +262,37 @@ pub fn CollisionEvent::removed(self : CollisionEvent) -> Bool {
     CollisionEvent::Stopped(_, _, flags) =>
       flags.contains(CollisionEventFlags::removed())
   }
+}
+
+///|
+pub struct IntersectionEvent {
+  collider1 : ColliderHandle
+  collider2 : ColliderHandle
+  intersecting : Bool
+}
+
+///|
+pub fn IntersectionEvent::new(
+  collider1 : ColliderHandle,
+  collider2 : ColliderHandle,
+  intersecting : Bool,
+) -> IntersectionEvent {
+  { collider1, collider2, intersecting }
+}
+
+///|
+pub fn IntersectionEvent::collider1(self : IntersectionEvent) -> ColliderHandle {
+  self.collider1
+}
+
+///|
+pub fn IntersectionEvent::collider2(self : IntersectionEvent) -> ColliderHandle {
+  self.collider2
+}
+
+///|
+pub fn IntersectionEvent::intersecting(self : IntersectionEvent) -> Bool {
+  self.intersecting
 }
 
 ///|

--- a/collision/events3d.mbt
+++ b/collision/events3d.mbt
@@ -69,3 +69,38 @@ pub fn CollisionEvent3D::removed(self : CollisionEvent3D) -> Bool {
       flags.contains(CollisionEventFlags::removed())
   }
 }
+
+///|
+pub struct IntersectionEvent3D {
+  collider1 : ColliderHandle3D
+  collider2 : ColliderHandle3D
+  intersecting : Bool
+}
+
+///|
+pub fn IntersectionEvent3D::new(
+  collider1 : ColliderHandle3D,
+  collider2 : ColliderHandle3D,
+  intersecting : Bool,
+) -> IntersectionEvent3D {
+  { collider1, collider2, intersecting }
+}
+
+///|
+pub fn IntersectionEvent3D::collider1(
+  self : IntersectionEvent3D,
+) -> ColliderHandle3D {
+  self.collider1
+}
+
+///|
+pub fn IntersectionEvent3D::collider2(
+  self : IntersectionEvent3D,
+) -> ColliderHandle3D {
+  self.collider2
+}
+
+///|
+pub fn IntersectionEvent3D::intersecting(self : IntersectionEvent3D) -> Bool {
+  self.intersecting
+}

--- a/collision/pkg.generated.mbti
+++ b/collision/pkg.generated.mbti
@@ -133,6 +133,7 @@ pub fn ActiveEvents::from_bits_retain(Int) -> Self
 pub fn ActiveEvents::from_bits_truncate(Int) -> Self
 pub fn ActiveEvents::from_name(String) -> Self?
 pub fn ActiveEvents::insert(Self, Self) -> Self
+pub fn ActiveEvents::intersection_events() -> Self
 pub fn ActiveEvents::is_all(Self) -> Bool
 pub fn ActiveEvents::iter_names(Self) -> Array[String]
 pub fn ActiveEvents::symmetric_difference(Self, Self) -> Self
@@ -778,6 +779,26 @@ pub fn[T] InteractionGraph::interactions_with_endpoints(Self[T], ColliderHandle,
 pub fn[T] InteractionGraph::interactions_with_mut(Self[T], ColliderHandle) -> Array[(ColliderHandle, ColliderHandle, T)]
 pub fn[T] InteractionGraph::new() -> Self[T]
 pub fn[T] InteractionGraph::raw_graph(Self[T]) -> Array[(ColliderHandle, ColliderHandle, T)]
+
+pub struct IntersectionEvent {
+  collider1 : ColliderHandle
+  collider2 : ColliderHandle
+  intersecting : Bool
+}
+pub fn IntersectionEvent::collider1(Self) -> ColliderHandle
+pub fn IntersectionEvent::collider2(Self) -> ColliderHandle
+pub fn IntersectionEvent::intersecting(Self) -> Bool
+pub fn IntersectionEvent::new(ColliderHandle, ColliderHandle, Bool) -> Self
+
+pub struct IntersectionEvent3D {
+  collider1 : ColliderHandle3D
+  collider2 : ColliderHandle3D
+  intersecting : Bool
+}
+pub fn IntersectionEvent3D::collider1(Self) -> ColliderHandle3D
+pub fn IntersectionEvent3D::collider2(Self) -> ColliderHandle3D
+pub fn IntersectionEvent3D::intersecting(Self) -> Bool
+pub fn IntersectionEvent3D::new(ColliderHandle3D, ColliderHandle3D, Bool) -> Self
 
 pub struct IntersectionPair {
   collider1 : ColliderHandle

--- a/collision/spec.mbt
+++ b/collision/spec.mbt
@@ -105,6 +105,12 @@ pub fn ActiveEvents::contact_force_events() -> ActiveEvents {
 
 ///|
 #declaration_only
+pub fn ActiveEvents::intersection_events() -> ActiveEvents {
+  ...
+}
+
+///|
+#declaration_only
 pub fn ActiveEvents::contains(
   self : ActiveEvents,
   other : ActiveEvents,
@@ -200,6 +206,38 @@ pub fn CollisionEvent::sensor(self : CollisionEvent) -> Bool {
 ///|
 #declaration_only
 pub fn CollisionEvent::removed(self : CollisionEvent) -> Bool {
+  ...
+}
+
+///|
+#declaration_only
+pub type IntersectionEvent
+
+///|
+#declaration_only
+pub fn IntersectionEvent::new(
+  collider1 : ColliderHandle,
+  collider2 : ColliderHandle,
+  intersecting : Bool,
+) -> IntersectionEvent {
+  ...
+}
+
+///|
+#declaration_only
+pub fn IntersectionEvent::collider1(self : IntersectionEvent) -> ColliderHandle {
+  ...
+}
+
+///|
+#declaration_only
+pub fn IntersectionEvent::collider2(self : IntersectionEvent) -> ColliderHandle {
+  ...
+}
+
+///|
+#declaration_only
+pub fn IntersectionEvent::intersecting(self : IntersectionEvent) -> Bool {
   ...
 }
 

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "Milky2018/moon_rapier",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "readme": "README.md",
   "repository": "https://github.com/moonbit-community/moon_rapier",
   "license": "Apache-2.0",

--- a/pipeline/event_handler.mbt
+++ b/pipeline/event_handler.mbt
@@ -20,6 +20,12 @@ pub struct EventHandler {
     @collision.ColliderSet,
     @collision.CollisionEvent,
   ) -> Unit)?
+  intersection_events : Array[@collision.IntersectionEvent]
+  mut intersection_callback : ((
+    @dynamics.RigidBodySet,
+    @collision.ColliderSet,
+    @collision.IntersectionEvent,
+  ) -> Unit)?
   contact_force_events : Array[@collision.ContactForceEvent]
   mut contact_force_callback : ((
     @core.Real,
@@ -34,6 +40,8 @@ pub fn EventHandler::new() -> EventHandler {
   {
     collision_events: [],
     collision_callback: None,
+    intersection_events: [],
+    intersection_callback: None,
     contact_force_events: [],
     contact_force_callback: None,
   }
@@ -63,6 +71,32 @@ pub fn EventHandler::handle_collision_event(
     callback(bodies, colliders, event)
   }
   self.collision_events.push(event)
+}
+
+///|
+pub fn EventHandler::on_intersection_event(
+  self : EventHandler,
+  callback : (
+    @dynamics.RigidBodySet,
+    @collision.ColliderSet,
+    @collision.IntersectionEvent,
+  ) -> Unit,
+) -> EventHandler {
+  self.intersection_callback = Some(callback)
+  self
+}
+
+///|
+pub fn EventHandler::handle_intersection_event(
+  self : EventHandler,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
+  event : @collision.IntersectionEvent,
+) -> Unit {
+  if self.intersection_callback is Some(callback) {
+    callback(bodies, colliders, event)
+  }
+  self.intersection_events.push(event)
 }
 
 ///|
@@ -102,6 +136,14 @@ pub fn EventHandler::push_collision_event(
 }
 
 ///|
+pub fn EventHandler::push_intersection_event(
+  self : EventHandler,
+  event : @collision.IntersectionEvent,
+) -> Unit {
+  self.intersection_events.push(event)
+}
+
+///|
 pub fn EventHandler::push_contact_force_event(
   self : EventHandler,
   event : @collision.ContactForceEvent,
@@ -118,6 +160,18 @@ pub fn EventHandler::take_collision_events(
     result.push(self.collision_events[i])
   }
   self.collision_events.clear()
+  result
+}
+
+///|
+pub fn EventHandler::take_intersection_events(
+  self : EventHandler,
+) -> Array[@collision.IntersectionEvent] {
+  let result : Array[@collision.IntersectionEvent] = []
+  for i in 0..<self.intersection_events.length() {
+    result.push(self.intersection_events[i])
+  }
+  self.intersection_events.clear()
   result
 }
 
@@ -154,6 +208,16 @@ pub fn ChannelEventCollector::handle_collision_event(
 }
 
 ///|
+pub fn ChannelEventCollector::handle_intersection_event(
+  self : ChannelEventCollector,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
+  event : @collision.IntersectionEvent,
+) -> Unit {
+  self.handler.handle_intersection_event(bodies, colliders, event)
+}
+
+///|
 pub fn ChannelEventCollector::handle_contact_force_event(
   self : ChannelEventCollector,
   dt : @core.Real,
@@ -169,6 +233,13 @@ pub fn ChannelEventCollector::take_collision_events(
   self : ChannelEventCollector,
 ) -> Array[@collision.CollisionEvent] {
   self.handler.take_collision_events()
+}
+
+///|
+pub fn ChannelEventCollector::take_intersection_events(
+  self : ChannelEventCollector,
+) -> Array[@collision.IntersectionEvent] {
+  self.handler.take_intersection_events()
 }
 
 ///|

--- a/pipeline/event_handler3d.mbt
+++ b/pipeline/event_handler3d.mbt
@@ -15,11 +15,12 @@
 ///|
 pub struct EventHandler3D {
   collision_events : Array[@collision.CollisionEvent3D]
+  intersection_events : Array[@collision.IntersectionEvent3D]
 }
 
 ///|
 pub fn EventHandler3D::new() -> EventHandler3D {
-  { collision_events: [] }
+  { collision_events: [], intersection_events: [] }
 }
 
 ///|
@@ -31,6 +32,14 @@ pub fn EventHandler3D::push_collision_event(
 }
 
 ///|
+pub fn EventHandler3D::push_intersection_event(
+  self : EventHandler3D,
+  event : @collision.IntersectionEvent3D,
+) -> Unit {
+  self.intersection_events.push(event)
+}
+
+///|
 pub fn EventHandler3D::take_collision_events(
   self : EventHandler3D,
 ) -> Array[@collision.CollisionEvent3D] {
@@ -39,5 +48,17 @@ pub fn EventHandler3D::take_collision_events(
     out.push(self.collision_events[i])
   }
   self.collision_events.clear()
+  out
+}
+
+///|
+pub fn EventHandler3D::take_intersection_events(
+  self : EventHandler3D,
+) -> Array[@collision.IntersectionEvent3D] {
+  let out : Array[@collision.IntersectionEvent3D] = []
+  for i in 0..<self.intersection_events.length() {
+    out.push(self.intersection_events[i])
+  }
+  self.intersection_events.clear()
   out
 }

--- a/pipeline/event_handler_test.mbt
+++ b/pipeline/event_handler_test.mbt
@@ -52,3 +52,33 @@ test "event handler collects contact force events and invokes callback" {
     content="true",
   )
 }
+
+///|
+test "event handler collects intersection events and invokes callback" {
+  let bodies = @dynamics.RigidBodySet::new()
+  let colliders = @collision.ColliderSet::new()
+  let h1 = colliders.insert(@collision.ColliderBuilder::ball(0.5F).build())
+  let h2 = colliders.insert(@collision.ColliderBuilder::ball(0.5F).build())
+  let event = @collision.IntersectionEvent::new(h1, h2, true)
+  let seen : Array[@collision.IntersectionEvent] = []
+  let handler = EventHandler::new().on_intersection_event(fn(
+    _bodies : @dynamics.RigidBodySet,
+    _colliders : @collision.ColliderSet,
+    event : @collision.IntersectionEvent,
+  ) -> Unit {
+    seen.push(event)
+  })
+  handler.handle_intersection_event(bodies, colliders, event)
+  inspect(seen.length() == 1, content="true")
+  let collected = handler.take_intersection_events()
+  inspect(collected.length() == 1, content="true")
+  inspect(
+    @collision.ColliderHandle::equals(collected[0].collider1(), h1),
+    content="true",
+  )
+  inspect(
+    @collision.ColliderHandle::equals(collected[0].collider2(), h2),
+    content="true",
+  )
+  inspect(collected[0].intersecting(), content="true")
+}

--- a/pipeline/physics_pipeline.mbt
+++ b/pipeline/physics_pipeline.mbt
@@ -22,6 +22,9 @@ pub struct PhysicsPipeline {
       Bool,
     ),
   ]
+  prev_intersections : Array[
+    (@collision.ColliderHandle, @collision.ColliderHandle, Bool),
+  ]
   contact_solver_cache : Array[ContactImpulseCacheEntry]
   counters : @counters.Counters
 }
@@ -30,6 +33,7 @@ pub struct PhysicsPipeline {
 pub fn PhysicsPipeline::new() -> PhysicsPipeline {
   {
     prev_collisions: [],
+    prev_intersections: [],
     contact_solver_cache: [],
     counters: @counters.Counters::default(),
   }
@@ -926,6 +930,28 @@ fn should_emit_collision_events(
 }
 
 ///|
+fn should_emit_intersection_events(
+  colliders : @collision.ColliderSet,
+  h1 : @collision.ColliderHandle,
+  h2 : @collision.ColliderHandle,
+) -> Bool {
+  fn has_intersection_events(collider : @collision.Collider) -> Bool {
+    collider
+    .active_events()
+    .contains(@collision.ActiveEvents::intersection_events())
+  }
+
+  let mut enabled = false
+  if colliders.get(h1) is Some(c1) {
+    enabled = enabled || has_intersection_events(c1)
+  }
+  if colliders.get(h2) is Some(c2) {
+    enabled = enabled || has_intersection_events(c2)
+  }
+  enabled
+}
+
+///|
 fn collect_current_collisions(
   narrow_phase : @collision.NarrowPhase,
   colliders : @collision.ColliderSet,
@@ -968,6 +994,38 @@ fn collect_current_collisions(
     let flags = compute_collision_event_flags(colliders, pair.0, pair.1)
     let emit = should_emit_collision_events(colliders, pair.0, pair.1)
     result.push((pair.0, pair.1, flags, emit))
+  }
+  result
+}
+
+///|
+fn collect_current_intersections(
+  narrow_phase : @collision.NarrowPhase,
+  colliders : @collision.ColliderSet,
+) -> Array[(@collision.ColliderHandle, @collision.ColliderHandle, Bool)] {
+  let result : Array[
+    (@collision.ColliderHandle, @collision.ColliderHandle, Bool),
+  ] = []
+  let intersections = narrow_phase.intersection_pairs()
+  for i in 0..<intersections.length() {
+    let pair = intersections[i]
+    if !pair.intersecting {
+      continue
+    }
+    let flags = compute_collision_event_flags(
+      colliders,
+      pair.collider1,
+      pair.collider2,
+    )
+    if !flags.contains(@collision.CollisionEventFlags::sensor()) {
+      continue
+    }
+    let emit = should_emit_intersection_events(
+      colliders,
+      pair.collider1,
+      pair.collider2,
+    )
+    result.push((pair.collider1, pair.collider2, emit))
   }
   result
 }
@@ -1018,6 +1076,51 @@ fn PhysicsPipeline::emit_collision_events(
   self.prev_collisions.clear()
   for i in 0..<current.length() {
     self.prev_collisions.push(current[i])
+  }
+}
+
+///|
+fn PhysicsPipeline::emit_intersection_events(
+  self : PhysicsPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
+  narrow_phase : @collision.NarrowPhase,
+  event_handler : EventHandler,
+) -> Unit {
+  let current = collect_current_intersections(narrow_phase, colliders)
+  let prev_pairs : Array[(@collision.ColliderHandle, @collision.ColliderHandle)] = []
+  for i in 0..<self.prev_intersections.length() {
+    let p = self.prev_intersections[i]
+    prev_pairs.push((p.0, p.1))
+  }
+  let cur_pairs : Array[(@collision.ColliderHandle, @collision.ColliderHandle)] = []
+  for i in 0..<current.length() {
+    let c = current[i]
+    cur_pairs.push((c.0, c.1))
+  }
+  for i in 0..<current.length() {
+    let c = current[i]
+    if !collision_pair_in_list((c.0, c.1), prev_pairs) && c.2 {
+      event_handler.handle_intersection_event(
+        bodies,
+        colliders,
+        @collision.IntersectionEvent::new(c.0, c.1, true),
+      )
+    }
+  }
+  for i in 0..<self.prev_intersections.length() {
+    let p = self.prev_intersections[i]
+    if !collision_pair_in_list((p.0, p.1), cur_pairs) && p.2 {
+      event_handler.handle_intersection_event(
+        bodies,
+        colliders,
+        @collision.IntersectionEvent::new(p.0, p.1, false),
+      )
+    }
+  }
+  self.prev_intersections.clear()
+  for i in 0..<current.length() {
+    self.prev_intersections.push(current[i])
   }
 }
 
@@ -1314,6 +1417,9 @@ pub fn PhysicsPipeline::step(
   }
   // Only emit collision events after the final collision detection pass.
   PhysicsPipeline::emit_collision_events(
+    self, bodies, colliders, narrow_phase, event_handler,
+  )
+  PhysicsPipeline::emit_intersection_events(
     self, bodies, colliders, narrow_phase, event_handler,
   )
   let contacts = @dynamics.ContactGraph::new()

--- a/pipeline/physics_pipeline3d_real.mbt
+++ b/pipeline/physics_pipeline3d_real.mbt
@@ -24,6 +24,9 @@ pub struct PhysicsPipeline3DReal {
   contact_pairs : Array[
     (@collision.ColliderHandle3D, @collision.ColliderHandle3D),
   ]
+  intersection_pairs : Array[
+    (@collision.ColliderHandle3D, @collision.ColliderHandle3D),
+  ]
 }
 
 ///|
@@ -32,6 +35,7 @@ pub fn PhysicsPipeline3DReal::new() -> PhysicsPipeline3DReal {
     contact_cache: ContactSolverCache3D::new(),
     sensor_pairs: [],
     contact_pairs: [],
+    intersection_pairs: [],
   }
 }
 
@@ -328,6 +332,41 @@ fn collect_sensor_pairs(
 }
 
 ///|
+fn collect_intersection_pairs(
+  narrow_phase : @collision.NarrowPhase3D,
+  colliders : @collision.ColliderSet3D,
+) -> Array[(@collision.ColliderHandle3D, @collision.ColliderHandle3D)] {
+  let out : Array[(@collision.ColliderHandle3D, @collision.ColliderHandle3D)] = []
+  let all = narrow_phase.all_intersection_pairs()
+  for i in 0..<all.length() {
+    let pair = all[i].0
+    let ip = all[i].1
+    if !ip.intersecting() {
+      continue
+    }
+    let (a, b) = canonical_pair_3d(pair.0, pair.1)
+    if colliders.get(a) is Some(ca) && colliders.get(b) is Some(cb) {
+      let sensor = ca.is_sensor() || cb.is_sensor()
+      if !sensor {
+        continue
+      }
+      let wants = ca
+        .active_events()
+        .contains(@collision.ActiveEvents::intersection_events()) ||
+        cb
+        .active_events()
+        .contains(@collision.ActiveEvents::intersection_events())
+      if !wants {
+        continue
+      }
+      out.push((a, b))
+    }
+  }
+  sort_pairs_3d(out)
+  out
+}
+
+///|
 fn collect_contact_pairs(
   narrow_phase : @collision.NarrowPhase3D,
   colliders : @collision.ColliderSet3D,
@@ -397,6 +436,51 @@ fn emit_collision_events_for_pair_diffs(
     } else if pair_less_3d(b, a) {
       handler.push_collision_event(
         @collision.CollisionEvent3D::Started(b.0, b.1, flags),
+      )
+      j = j + 1
+    } else {
+      i = i + 1
+      j = j + 1
+    }
+  }
+}
+
+///|
+fn emit_intersection_events_for_pair_diffs(
+  handler : EventHandler3D,
+  prev_pairs : Array[(@collision.ColliderHandle3D, @collision.ColliderHandle3D)],
+  next_pairs : Array[(@collision.ColliderHandle3D, @collision.ColliderHandle3D)],
+) -> Unit {
+  sort_pairs_3d(prev_pairs)
+  let mut i = 0
+  let mut j = 0
+  while i < prev_pairs.length() || j < next_pairs.length() {
+    if i >= prev_pairs.length() {
+      let p = next_pairs[j]
+      handler.push_intersection_event(
+        @collision.IntersectionEvent3D::new(p.0, p.1, true),
+      )
+      j = j + 1
+      continue
+    }
+    if j >= next_pairs.length() {
+      let p = prev_pairs[i]
+      handler.push_intersection_event(
+        @collision.IntersectionEvent3D::new(p.0, p.1, false),
+      )
+      i = i + 1
+      continue
+    }
+    let a = prev_pairs[i]
+    let b = next_pairs[j]
+    if pair_less_3d(a, b) {
+      handler.push_intersection_event(
+        @collision.IntersectionEvent3D::new(a.0, a.1, false),
+      )
+      i = i + 1
+    } else if pair_less_3d(b, a) {
+      handler.push_intersection_event(
+        @collision.IntersectionEvent3D::new(b.0, b.1, true),
       )
       j = j + 1
     } else {
@@ -711,6 +795,9 @@ fn PhysicsPipeline3DReal::step_impl_one(
     broad_phase.update(prediction_distance, colliders)
     narrow_phase.update(broad_phase.pairs(), bodies, colliders)
     let next_sensor_pairs = collect_sensor_pairs(narrow_phase, colliders)
+    let next_intersection_pairs = collect_intersection_pairs(
+      narrow_phase, colliders,
+    )
     let next_contact_pairs = collect_contact_pairs(narrow_phase, colliders)
     let prev_sensor_pairs = self.sensor_pairs.copy()
     emit_collision_events_for_pair_diffs(
@@ -718,6 +805,10 @@ fn PhysicsPipeline3DReal::step_impl_one(
       prev_sensor_pairs,
       next_sensor_pairs,
       @collision.CollisionEventFlags::sensor(),
+    )
+    let prev_intersection_pairs = self.intersection_pairs.copy()
+    emit_intersection_events_for_pair_diffs(
+      handler, prev_intersection_pairs, next_intersection_pairs,
     )
     let prev_contact_pairs = self.contact_pairs.copy()
     emit_collision_events_for_pair_diffs(
@@ -728,6 +819,8 @@ fn PhysicsPipeline3DReal::step_impl_one(
     )
     self.sensor_pairs.clear()
     self.sensor_pairs.append(next_sensor_pairs[:])
+    self.intersection_pairs.clear()
+    self.intersection_pairs.append(next_intersection_pairs[:])
     self.contact_pairs.clear()
     self.contact_pairs.append(next_contact_pairs[:])
   }

--- a/pipeline/physics_pipeline3d_real_test.mbt
+++ b/pipeline/physics_pipeline3d_real_test.mbt
@@ -497,3 +497,98 @@ test "physics_pipeline3d_real: collision events do not repeat while sensor inter
   let ev2 = handler.take_collision_events()
   inspect(ev2.length(), content="0")
 }
+
+///|
+test "physics_pipeline3d_real: intersection events for sensor overlaps (without collision events)" {
+  let pipeline = PhysicsPipeline3DReal::new()
+  let broad_phase = @collision.BroadPhase3D::new()
+  let narrow_phase = @collision.NarrowPhase3D::new()
+  let islands = @dynamics.IslandManager3D::new()
+  let bodies = @dynamics.RigidBodySet3D::new()
+  let colliders = @collision.ColliderSet3D::new()
+  let gravity = @core.Vec3::zero()
+  let parameters = @dynamics.IntegrationParameters::default().set_dt(
+    1.0F / 60.0F,
+  )
+  let handler = EventHandler3D::new()
+  fn has_event(
+    events : Array[@collision.IntersectionEvent3D],
+    intersecting : Bool,
+    a : @collision.ColliderHandle3D,
+    b : @collision.ColliderHandle3D,
+  ) -> Bool {
+    for e in events {
+      if e.intersecting() != intersecting {
+        continue
+      }
+      let c1 = e.collider1()
+      let c2 = e.collider2()
+      if (c1.equals(a) && c2.equals(b)) || (c1.equals(b) && c2.equals(a)) {
+        return true
+      }
+    }
+    false
+  }
+
+  let ground = bodies.insert(
+    @dynamics.RigidBodyBuilder3D::fixed()
+    .translation(@core.Vec3::new(0.0F, -1.0F, 0.0F))
+    .build(),
+  )
+  let ground_collider = colliders.insert_with_parent(
+    @collision.ColliderBuilder3D::cuboid(10.0F, 1.0F, 10.0F).build(),
+    ground,
+    bodies,
+  )
+  let ball = bodies.insert(
+    @dynamics.RigidBodyBuilder3D::kinematic_position_based()
+    .translation(@core.Vec3::new(0.0F, 2.0F, 0.0F))
+    .build(),
+  )
+  let sensor_ball = colliders.insert_with_parent(
+    @collision.ColliderBuilder3D::ball(0.5F)
+    .sensor(true)
+    .active_events(@collision.ActiveEvents::intersection_events())
+    .build(),
+    ball,
+    bodies,
+  )
+
+  // Step once: no intersection, no events.
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  inspect(handler.take_collision_events().length(), content="0")
+  inspect(handler.take_intersection_events().length(), content="0")
+
+  // Step into intersection: expect intersecting=true, and no collision events.
+  if bodies.get(ball) is Some(rb) {
+    rb.set_next_kinematic_translation(@core.Vec3::new(0.0F, 0.4F, 0.0F))
+  } else {
+    inspect(false, content="true")
+  }
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  inspect(handler.take_collision_events().length(), content="0")
+  let ev1 = handler.take_intersection_events()
+  inspect(has_event(ev1, true, sensor_ball, ground_collider), content="true")
+
+  // Keep intersection: should emit no further events.
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  inspect(handler.take_intersection_events().length(), content="0")
+
+  // Step out of intersection: expect intersecting=false.
+  if bodies.get(ball) is Some(rb2) {
+    rb2.set_next_kinematic_translation(@core.Vec3::new(0.0F, 2.0F, 0.0F))
+  } else {
+    inspect(false, content="true")
+  }
+  pipeline.step_with_events(
+    gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders, handler,
+  )
+  let ev2 = handler.take_intersection_events()
+  inspect(has_event(ev2, false, sensor_ball, ground_collider), content="true")
+}

--- a/pipeline/physics_pipeline_test.mbt
+++ b/pipeline/physics_pipeline_test.mbt
@@ -1204,3 +1204,168 @@ test "rotated cuboid does not generate false contacts" {
     inspect(false, content="true")
   }
 }
+
+///|
+test "intersection events: sensor overlaps started/stopped (without collision events)" {
+  let pipeline = PhysicsPipeline::new()
+  let broad_phase = @collision.BroadPhaseBvh::new()
+  let narrow_phase = @collision.NarrowPhase::new()
+  let bodies = @dynamics.RigidBodySet::new()
+  let colliders = @collision.ColliderSet::new()
+  let islands = @dynamics.IslandManager::new()
+  let impulse_joints = @dynamics.ImpulseJointSet::new()
+  let multibody_joints = @dynamics.MultibodyJointSet::new()
+  let params = IntegrationParameters::default()
+  let gravity = @core.Vec2::zero()
+  let handler = EventHandler::new()
+  fn has_event(
+    events : Array[@collision.IntersectionEvent],
+    intersecting : Bool,
+    a : @collision.ColliderHandle,
+    b : @collision.ColliderHandle,
+  ) -> Bool {
+    for e in events {
+      if e.intersecting() != intersecting {
+        continue
+      }
+      let c1 = e.collider1()
+      let c2 = e.collider2()
+      if (
+          @collision.ColliderHandle::equals(c1, a) &&
+          @collision.ColliderHandle::equals(c2, b)
+        ) ||
+        (
+          @collision.ColliderHandle::equals(c1, b) &&
+          @collision.ColliderHandle::equals(c2, a)
+        ) {
+        return true
+      }
+    }
+    false
+  }
+
+  let ground = bodies.insert(
+    @dynamics.RigidBodyBuilder::fixed()
+    .translation(@core.Vec2::new(0.0F, 0.0F))
+    .build(),
+  )
+  let ground_collider = colliders.insert_with_parent(
+    @collision.ColliderBuilder::ball(0.5F).build(),
+    ground,
+    bodies,
+  )
+  let mover = bodies.insert(
+    @dynamics.RigidBodyBuilder::dynamic()
+    .translation(@core.Vec2::new(0.0F, 2.0F))
+    .build(),
+  )
+  let sensor_collider = colliders.insert_with_parent(
+    @collision.ColliderBuilder::ball(0.5F)
+    .sensor(true)
+    .active_events(@collision.ActiveEvents::intersection_events())
+    .build(),
+    mover,
+    bodies,
+  )
+
+  // Step once: no intersection, no events.
+  pipeline.step(
+    gravity,
+    params,
+    islands,
+    broad_phase,
+    narrow_phase,
+    bodies,
+    colliders,
+    impulse_joints,
+    multibody_joints,
+    @dynamics.CCDSolver::new(),
+    PhysicsHooks::new(),
+    handler,
+  )
+  inspect(handler.take_collision_events().length() == 0, content="true")
+  inspect(handler.take_intersection_events().length() == 0, content="true")
+
+  // Move into intersection: should emit intersecting=true.
+  if bodies.get_mut(mover) is Some(rb) {
+    rb.set_translation(@core.Vec2::new(0.0F, 0.0F), true) |> ignore
+  } else {
+    inspect(false, content="true")
+  }
+  pipeline.step(
+    gravity,
+    params,
+    islands,
+    broad_phase,
+    narrow_phase,
+    bodies,
+    colliders,
+    impulse_joints,
+    multibody_joints,
+    @dynamics.CCDSolver::new(),
+    PhysicsHooks::new(),
+    handler,
+  )
+  // Ensure the narrow-phase detected the intersection even when collision events are disabled.
+  inspect(narrow_phase.intersection_pairs().length() > 0, content="true")
+  if colliders.get(sensor_collider) is Some(sc) {
+    inspect(sc.is_sensor(), content="true")
+    inspect(
+      sc
+      .active_events()
+      .contains(@collision.ActiveEvents::intersection_events()),
+      content="true",
+    )
+  } else {
+    inspect(false, content="true")
+  }
+  inspect(handler.take_collision_events().length() == 0, content="true")
+  let ev1 = handler.take_intersection_events()
+  inspect(
+    has_event(ev1, true, sensor_collider, ground_collider),
+    content="true",
+  )
+
+  // Stay intersecting: no repeated event.
+  pipeline.step(
+    gravity,
+    params,
+    islands,
+    broad_phase,
+    narrow_phase,
+    bodies,
+    colliders,
+    impulse_joints,
+    multibody_joints,
+    @dynamics.CCDSolver::new(),
+    PhysicsHooks::new(),
+    handler,
+  )
+  inspect(handler.take_intersection_events().length() == 0, content="true")
+
+  // Move out of intersection: should emit intersecting=false.
+  if bodies.get_mut(mover) is Some(rb2) {
+    rb2.set_translation(@core.Vec2::new(0.0F, 2.0F), true) |> ignore
+  } else {
+    inspect(false, content="true")
+  }
+  pipeline.step(
+    gravity,
+    params,
+    islands,
+    broad_phase,
+    narrow_phase,
+    bodies,
+    colliders,
+    impulse_joints,
+    multibody_joints,
+    @dynamics.CCDSolver::new(),
+    PhysicsHooks::new(),
+    handler,
+  )
+  let ev2 = handler.take_intersection_events()
+  inspect(
+    has_event(ev2, false, sensor_collider, ground_collider),
+    content="true",
+  )
+}

--- a/pipeline/pkg.generated.mbti
+++ b/pipeline/pkg.generated.mbti
@@ -34,9 +34,11 @@ pub struct ChannelEventCollector {
 }
 pub fn ChannelEventCollector::handle_collision_event(Self, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.CollisionEvent) -> Unit
 pub fn ChannelEventCollector::handle_contact_force_event(Self, Float, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.ContactForceEvent) -> Unit
+pub fn ChannelEventCollector::handle_intersection_event(Self, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.IntersectionEvent) -> Unit
 pub fn ChannelEventCollector::new() -> Self
 pub fn ChannelEventCollector::take_collision_events(Self) -> Array[@collision.CollisionEvent]
 pub fn ChannelEventCollector::take_contact_force_events(Self) -> Array[@collision.ContactForceEvent]
+pub fn ChannelEventCollector::take_intersection_events(Self) -> Array[@collision.IntersectionEvent]
 
 pub struct CollisionPipeline {
 }
@@ -172,25 +174,34 @@ pub fn DebugRenderStyle::default() -> Self
 pub struct EventHandler {
   collision_events : Array[@collision.CollisionEvent]
   mut collision_callback : ((@dynamics.RigidBodySet, @collision.ColliderSet, @collision.CollisionEvent) -> Unit)?
+  intersection_events : Array[@collision.IntersectionEvent]
+  mut intersection_callback : ((@dynamics.RigidBodySet, @collision.ColliderSet, @collision.IntersectionEvent) -> Unit)?
   contact_force_events : Array[@collision.ContactForceEvent]
   mut contact_force_callback : ((Float, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.ContactForceEvent) -> Unit)?
 }
 pub fn EventHandler::handle_collision_event(Self, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.CollisionEvent) -> Unit
 pub fn EventHandler::handle_contact_force_event(Self, Float, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.ContactForceEvent) -> Unit
+pub fn EventHandler::handle_intersection_event(Self, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.IntersectionEvent) -> Unit
 pub fn EventHandler::new() -> Self
 pub fn EventHandler::on_collision_event(Self, (@dynamics.RigidBodySet, @collision.ColliderSet, @collision.CollisionEvent) -> Unit) -> Self
 pub fn EventHandler::on_contact_force_event(Self, (Float, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.ContactForceEvent) -> Unit) -> Self
+pub fn EventHandler::on_intersection_event(Self, (@dynamics.RigidBodySet, @collision.ColliderSet, @collision.IntersectionEvent) -> Unit) -> Self
 pub fn EventHandler::push_collision_event(Self, @collision.CollisionEvent) -> Unit
 pub fn EventHandler::push_contact_force_event(Self, @collision.ContactForceEvent) -> Unit
+pub fn EventHandler::push_intersection_event(Self, @collision.IntersectionEvent) -> Unit
 pub fn EventHandler::take_collision_events(Self) -> Array[@collision.CollisionEvent]
 pub fn EventHandler::take_contact_force_events(Self) -> Array[@collision.ContactForceEvent]
+pub fn EventHandler::take_intersection_events(Self) -> Array[@collision.IntersectionEvent]
 
 pub struct EventHandler3D {
   collision_events : Array[@collision.CollisionEvent3D]
+  intersection_events : Array[@collision.IntersectionEvent3D]
 }
 pub fn EventHandler3D::new() -> Self
 pub fn EventHandler3D::push_collision_event(Self, @collision.CollisionEvent3D) -> Unit
+pub fn EventHandler3D::push_intersection_event(Self, @collision.IntersectionEvent3D) -> Unit
 pub fn EventHandler3D::take_collision_events(Self) -> Array[@collision.CollisionEvent3D]
+pub fn EventHandler3D::take_intersection_events(Self) -> Array[@collision.IntersectionEvent3D]
 
 pub struct PairFilterContext {
   bodies : @dynamics.RigidBodySet
@@ -216,6 +227,7 @@ pub fn PhysicsHooks::new() -> Self
 
 pub struct PhysicsPipeline {
   prev_collisions : Array[(@collision.ColliderHandle, @collision.ColliderHandle, @collision.CollisionEventFlags, Bool)]
+  prev_intersections : Array[(@collision.ColliderHandle, @collision.ColliderHandle, Bool)]
   contact_solver_cache : Array[ContactImpulseCacheEntry]
   counters : @counters.Counters
 }
@@ -237,6 +249,7 @@ pub struct PhysicsPipeline3DReal {
   mut contact_cache : ContactSolverCache3D
   sensor_pairs : Array[(@collision.ColliderHandle3D, @collision.ColliderHandle3D)]
   contact_pairs : Array[(@collision.ColliderHandle3D, @collision.ColliderHandle3D)]
+  intersection_pairs : Array[(@collision.ColliderHandle3D, @collision.ColliderHandle3D)]
 }
 pub fn PhysicsPipeline3DReal::new() -> Self
 pub fn PhysicsPipeline3DReal::step(Self, @core.Vec3, @dynamics.IntegrationParameters, @dynamics.IslandManager3D, @collision.BroadPhase3D, @collision.NarrowPhase3D, @dynamics.RigidBodySet3D, @collision.ColliderSet3D) -> Unit

--- a/pipeline/spec.mbt
+++ b/pipeline/spec.mbt
@@ -51,6 +51,30 @@ pub fn EventHandler::handle_collision_event(
 
 ///|
 #declaration_only
+pub fn EventHandler::on_intersection_event(
+  self : EventHandler,
+  callback : (
+    @dynamics.RigidBodySet,
+    @collision.ColliderSet,
+    @collision.IntersectionEvent,
+  ) -> Unit,
+) -> EventHandler {
+  ...
+}
+
+///|
+#declaration_only
+pub fn EventHandler::handle_intersection_event(
+  self : EventHandler,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
+  event : @collision.IntersectionEvent,
+) -> Unit {
+  ...
+}
+
+///|
+#declaration_only
 pub fn EventHandler::on_contact_force_event(
   self : EventHandler,
   callback : (
@@ -86,6 +110,15 @@ pub fn EventHandler::push_collision_event(
 
 ///|
 #declaration_only
+pub fn EventHandler::push_intersection_event(
+  self : EventHandler,
+  event : @collision.IntersectionEvent,
+) -> Unit {
+  ...
+}
+
+///|
+#declaration_only
 pub fn EventHandler::push_contact_force_event(
   self : EventHandler,
   event : @collision.ContactForceEvent,
@@ -98,6 +131,14 @@ pub fn EventHandler::push_contact_force_event(
 pub fn EventHandler::take_collision_events(
   self : EventHandler,
 ) -> Array[@collision.CollisionEvent] {
+  ...
+}
+
+///|
+#declaration_only
+pub fn EventHandler::take_intersection_events(
+  self : EventHandler,
+) -> Array[@collision.IntersectionEvent] {
   ...
 }
 


### PR DESCRIPTION
Implements GitHub issue #10.

- Add IntersectionEvent (2D) / IntersectionEvent3D (3D) for sensor overlaps.
- Add ActiveEvents::intersection_events() bit to enable intersection events independently of collision events.
- Extend pipeline EventHandler / EventHandler3D with push/take APIs (and callback for 2D).
- Emit intersection events from 2D PhysicsPipeline and 3DReal PhysicsPipeline3DReal by diffing sensor overlap pairs.
- Add regression tests.

BD: moon_rapier-feature-intersection-events