### PR TITLE
Add UserData128 for bodies/colliders (fix #11)

### DIFF
--- a/collision/collider3d.mbt
+++ b/collision/collider3d.mbt
@@ -355,6 +355,7 @@ pub struct Collider3D {
   mut one_way_offset : @core.Real?
   mut one_way_direction : Int // 1 = allow from above, -1 = allow from below, 0 = disabled
   active_events : ActiveEvents
+  mut user_data : @core.UserData128
   collision_groups : @dynamics.InteractionGroups
   friction : @core.Real
   restitution : @core.Real
@@ -484,6 +485,31 @@ pub fn Collider3D::active_events(self : Collider3D) -> ActiveEvents {
 }
 
 ///|
+pub fn Collider3D::user_data(self : Collider3D) -> Int {
+  self.user_data.to_int_truncate()
+}
+
+///|
+pub fn Collider3D::user_data128(self : Collider3D) -> @core.UserData128 {
+  self.user_data
+}
+
+///|
+pub fn Collider3D::set_user_data(self : Collider3D, data : Int) -> Collider3D {
+  self.user_data = @core.UserData128::from_int_truncate(data)
+  self
+}
+
+///|
+pub fn Collider3D::set_user_data128(
+  self : Collider3D,
+  data : @core.UserData128,
+) -> Collider3D {
+  self.user_data = data
+  self
+}
+
+///|
 pub fn Collider3D::collision_groups(
   self : Collider3D,
 ) -> @dynamics.InteractionGroups {
@@ -537,6 +563,7 @@ pub struct ColliderBuilder3D {
   mut one_way_offset : @core.Real?
   mut one_way_direction : Int
   mut active_events : ActiveEvents
+  mut user_data : @core.UserData128
   mut collision_groups : @dynamics.InteractionGroups
   mut friction : @core.Real
   mut restitution : @core.Real
@@ -556,6 +583,7 @@ pub fn ColliderBuilder3D::ball(radius : @core.Real) -> ColliderBuilder3D {
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -580,6 +608,7 @@ pub fn ColliderBuilder3D::cuboid(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -603,6 +632,7 @@ pub fn ColliderBuilder3D::capsule_y(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -647,6 +677,7 @@ pub fn ColliderBuilder3D::cylinder(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -671,6 +702,7 @@ pub fn ColliderBuilder3D::round_cylinder(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -694,6 +726,7 @@ pub fn ColliderBuilder3D::cone(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -725,6 +758,7 @@ pub fn ColliderBuilder3D::halfspace(normal : @core.Vec3) -> ColliderBuilder3D {
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -749,6 +783,7 @@ pub fn ColliderBuilder3D::triangle(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -801,6 +836,7 @@ pub fn ColliderBuilder3D::trimesh(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -859,6 +895,7 @@ pub fn ColliderBuilder3D::compound(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -893,6 +930,7 @@ pub fn ColliderBuilder3D::round_convex_hull(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -1049,6 +1087,7 @@ pub fn ColliderBuilder3D::round_convex_decomposition(
       one_way_offset: None,
       one_way_direction: 0,
       active_events: ActiveEvents::empty(),
+      user_data: @core.UserData128::zero(),
       collision_groups: @dynamics.InteractionGroups::all(),
       friction: 0.7F,
       restitution: 0.0F,
@@ -1269,6 +1308,7 @@ pub fn ColliderBuilder3D::voxels_from_points(
     one_way_offset: None,
     one_way_direction: 0,
     active_events: ActiveEvents::empty(),
+    user_data: @core.UserData128::zero(),
     collision_groups: @dynamics.InteractionGroups::all(),
     friction: 0.7F,
     restitution: 0.0F,
@@ -1331,6 +1371,7 @@ pub fn ColliderBuilder3D::heightfield(
           one_way_offset: None,
           one_way_direction: 0,
           active_events: ActiveEvents::empty(),
+          user_data: @core.UserData128::zero(),
           collision_groups: @dynamics.InteractionGroups::all(),
           friction: 0.7F,
           restitution: 0.0F,
@@ -1448,6 +1489,24 @@ pub fn ColliderBuilder3D::active_events(
 }
 
 ///|
+pub fn ColliderBuilder3D::user_data(
+  self : ColliderBuilder3D,
+  data : Int,
+) -> ColliderBuilder3D {
+  self.user_data = @core.UserData128::from_int_truncate(data)
+  self
+}
+
+///|
+pub fn ColliderBuilder3D::user_data128(
+  self : ColliderBuilder3D,
+  data : @core.UserData128,
+) -> ColliderBuilder3D {
+  self.user_data = data
+  self
+}
+
+///|
 pub fn ColliderBuilder3D::density(
   self : ColliderBuilder3D,
   density : @core.Real,
@@ -1497,6 +1556,7 @@ pub fn ColliderBuilder3D::build(self : ColliderBuilder3D) -> Collider3D {
     one_way_offset: self.one_way_offset,
     one_way_direction: self.one_way_direction,
     active_events: self.active_events,
+    user_data: self.user_data,
     collision_groups: self.collision_groups,
     friction: self.friction,
     restitution: self.restitution,

--- a/collision/collider3d_test.mbt
+++ b/collision/collider3d_test.mbt
@@ -79,3 +79,10 @@ test "collider3d round_cylinder aabb" {
   inspect(@core.abs(aabb.maxs.y - 2.25F) < 1.0e-6F, content="true")
   inspect(@core.abs(aabb.maxs.z - 1.25F) < 1.0e-6F, content="true")
 }
+
+///|
+test "collider3d user_data128 stored on build" {
+  let data = @core.UserData128::from_parts(10UL, 20UL)
+  let co = ColliderBuilder3D::ball(0.5F).user_data128(data).build()
+  inspect(co.user_data128().equals(data), content="true")
+}

--- a/collision/collider_set.mbt
+++ b/collision/collider_set.mbt
@@ -549,7 +549,7 @@ pub struct Collider {
   mut restitution_combine_rule : @dynamics.CoefficientCombineRule
   mut contact_skin : @core.Real
   mut contact_force_event_threshold : @core.Real
-  mut user_data : Int
+  mut user_data : @core.UserData128
   mut parent : @dynamics.RigidBodyHandle?
   mut enabled : ColliderEnabled
   mut changes : ColliderChanges
@@ -573,7 +573,7 @@ pub struct ColliderBuilder {
   mut restitution_combine_rule : @dynamics.CoefficientCombineRule
   mut contact_skin : @core.Real
   mut contact_force_event_threshold : @core.Real
-  mut user_data : Int
+  mut user_data : @core.UserData128
   mut enabled : Bool
 }
 
@@ -606,7 +606,7 @@ pub fn ColliderBuilder::ball(radius : @core.Real) -> ColliderBuilder {
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   }
 }
@@ -633,7 +633,7 @@ pub fn ColliderBuilder::cuboid(
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   }
 }
@@ -669,7 +669,7 @@ pub fn ColliderBuilder::capsule_x(
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   }
 }
@@ -696,7 +696,7 @@ pub fn ColliderBuilder::capsule_y(
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   }
 }
@@ -797,7 +797,7 @@ pub fn ColliderBuilder::compound(
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   }
 }
@@ -836,7 +836,7 @@ pub fn ColliderBuilder::segment(
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   }
 }
@@ -876,7 +876,7 @@ pub fn ColliderBuilder::polyline(
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   }
 }
@@ -958,7 +958,7 @@ pub fn ColliderBuilder::trimesh(
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   })
 }
@@ -1205,7 +1205,7 @@ pub fn ColliderBuilder::convex_hull(
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   })
 }
@@ -1359,6 +1359,15 @@ pub fn ColliderBuilder::contact_force_event_threshold(
 pub fn ColliderBuilder::user_data(
   self : ColliderBuilder,
   data : Int,
+) -> ColliderBuilder {
+  self.user_data = @core.UserData128::from_int_truncate(data)
+  self
+}
+
+///|
+pub fn ColliderBuilder::user_data128(
+  self : ColliderBuilder,
+  data : @core.UserData128,
 ) -> ColliderBuilder {
   self.user_data = data
   self
@@ -1657,6 +1666,11 @@ pub fn Collider::contact_force_event_threshold(self : Collider) -> @core.Real {
 
 ///|
 pub fn Collider::user_data(self : Collider) -> Int {
+  self.user_data.to_int_truncate()
+}
+
+///|
+pub fn Collider::user_data128(self : Collider) -> @core.UserData128 {
   self.user_data
 }
 
@@ -1982,6 +1996,15 @@ pub fn Collider::set_contact_force_event_threshold(
 
 ///|
 pub fn Collider::set_user_data(self : Collider, data : Int) -> Collider {
+  self.user_data = @core.UserData128::from_int_truncate(data)
+  self
+}
+
+///|
+pub fn Collider::set_user_data128(
+  self : Collider,
+  data : @core.UserData128,
+) -> Collider {
   self.user_data = data
   self
 }
@@ -2131,6 +2154,19 @@ fn parse_real_value(text : String) -> @core.Real {
     Float::from_double(value)
   } else {
     0.0F
+  }
+}
+
+///|
+fn parse_u64_value(text : String) -> UInt64 {
+  let result : Result[UInt64, @strconv.StrConvError] = try? @strconv.parse_uint64(
+    text[:],
+    base=10,
+  )
+  if result is Ok(value) {
+    value
+  } else {
+    UInt64::default()
   }
 }
 
@@ -2588,13 +2624,17 @@ pub fn ColliderSet::serialize(self : ColliderSet) -> String {
       sb.write_char('^')
       sb.write_object(collider.contact_force_event_threshold)
       sb.write_char('^')
-      sb.write_object(collider.user_data)
+      sb.write_object(collider.user_data.to_int_truncate())
       sb.write_char('^')
       sb.write_object(pid)
       sb.write_char('^')
       sb.write_object(pgen)
       sb.write_char('^')
       sb.write_object(collider_enabled_to_int(collider.enabled))
+      sb.write_char('^')
+      sb.write_string(collider.user_data.hi().to_string())
+      sb.write_char('^')
+      sb.write_string(collider.user_data.lo().to_string())
     } else {
       sb.write_char('N')
     }
@@ -2740,7 +2780,7 @@ pub fn ColliderSet::deserialize(data : String) -> ColliderSet {
           } else {
             0.0F
           }
-          let user_data = if fields.length() > 22 {
+          let user_data_int = if fields.length() > 22 {
             parse_int_value(fields[22])
           } else {
             0
@@ -2766,6 +2806,13 @@ pub fn ColliderSet::deserialize(data : String) -> ColliderSet {
             collider_enabled_from_int(parse_int_value(fields[25]))
           } else {
             ColliderEnabled::Enabled
+          }
+          let user_data = if fields.length() > 27 {
+            let hi = parse_u64_value(fields[26])
+            let lo = parse_u64_value(fields[27])
+            @core.UserData128::from_parts(hi, lo)
+          } else {
+            @core.UserData128::from_int_truncate(user_data_int)
           }
           let collider : Collider = {
             shape,

--- a/collision/collider_test.mbt
+++ b/collision/collider_test.mbt
@@ -276,6 +276,22 @@ test "collider material and event accessors" {
 }
 
 ///|
+test "collider user_data128 roundtrip through ColliderSet serialize/deserialize" {
+  let colliders = ColliderSet::new()
+  let data = @core.UserData128::from_parts(1UL, 2UL)
+  let h = colliders.insert(
+    ColliderBuilder::ball(0.5F).user_data128(data).build(),
+  )
+  let snapshot = colliders.serialize()
+  let colliders2 = ColliderSet::deserialize(snapshot)
+  if colliders2.get(h) is Some(c) {
+    inspect(c.user_data128().equals(data), content="true")
+  } else {
+    inspect(false, content="true")
+  }
+}
+
+///|
 test "convex polygon contacts cuboid" {
   let bodies = @dynamics.RigidBodySet::new()
   let colliders = ColliderSet::new()

--- a/collision/moon.pkg.json
+++ b/collision/moon.pkg.json
@@ -5,6 +5,7 @@
     "moonbitlang/core/hashmap",
     "moonbitlang/core/hashset",
     "moonbitlang/core/math",
+    "moonbitlang/core/uint64",
     "moonbitlang/core/strconv"
   ]
 }

--- a/collision/pkg.generated.mbti
+++ b/collision/pkg.generated.mbti
@@ -231,7 +231,7 @@ pub struct Collider {
   mut restitution_combine_rule : @dynamics.CoefficientCombineRule
   mut contact_skin : Float
   mut contact_force_event_threshold : Float
-  mut user_data : Int
+  mut user_data : @core.UserData128
   mut parent : @dynamics.RigidBodyHandle?
   mut enabled : ColliderEnabled
   mut changes : ColliderChanges
@@ -281,6 +281,7 @@ pub fn Collider::set_solver_groups(Self, @dynamics.InteractionGroups) -> Self
 pub fn Collider::set_translation(Self, @core.Vec2) -> Self
 pub fn Collider::set_translation_wrt_parent(Self, @core.Vec2) -> Self
 pub fn Collider::set_user_data(Self, Int) -> Self
+pub fn Collider::set_user_data128(Self, @core.UserData128) -> Self
 pub fn Collider::shape(Self) -> Shape
 pub fn Collider::shape_mut(Self) -> Shape
 pub fn Collider::shared_shape(Self) -> SharedShape
@@ -288,6 +289,7 @@ pub fn Collider::solver_groups(Self) -> @dynamics.InteractionGroups
 pub fn Collider::translation(Self) -> @core.Vec2
 pub fn Collider::translation3(Self) -> @core.Vec3
 pub fn Collider::user_data(Self) -> Int
+pub fn Collider::user_data128(Self) -> @core.UserData128
 pub fn Collider::volume(Self) -> Float
 
 pub struct Collider3D {
@@ -302,6 +304,7 @@ pub struct Collider3D {
   mut one_way_offset : Float?
   mut one_way_direction : Int
   active_events : ActiveEvents
+  mut user_data : @core.UserData128
   collision_groups : @dynamics.InteractionGroups
   friction : Float
   restitution : Float
@@ -327,8 +330,12 @@ pub fn Collider3D::set_parent(Self, @dynamics.RigidBodyHandle?) -> Unit
 pub fn Collider3D::set_position(Self, @core.Isometry3) -> Unit
 pub fn Collider3D::set_shape(Self, Shape3D) -> Unit
 pub fn Collider3D::set_surface_velocity(Self, @core.Vec3) -> Unit
+pub fn Collider3D::set_user_data(Self, Int) -> Self
+pub fn Collider3D::set_user_data128(Self, @core.UserData128) -> Self
 pub fn Collider3D::shape(Self) -> Shape3D
 pub fn Collider3D::surface_velocity(Self) -> @core.Vec3
+pub fn Collider3D::user_data(Self) -> Int
+pub fn Collider3D::user_data128(Self) -> @core.UserData128
 pub fn Collider3D::voxel_key_for_triangle(Self, Int) -> (Int, Int, Int)?
 
 pub struct ColliderBuilder {
@@ -348,7 +355,7 @@ pub struct ColliderBuilder {
   mut restitution_combine_rule : @dynamics.CoefficientCombineRule
   mut contact_skin : Float
   mut contact_force_event_threshold : Float
-  mut user_data : Int
+  mut user_data : @core.UserData128
   mut enabled : Bool
 }
 pub fn ColliderBuilder::active_collision_types(Self, ActiveCollisionTypes) -> Self
@@ -395,6 +402,7 @@ pub fn ColliderBuilder::triangle(@core.Vec2, @core.Vec2, @core.Vec2) -> Self
 pub fn ColliderBuilder::trimesh(Array[@core.Vec2], Array[(Int, Int, Int)]) -> Self?
 pub fn ColliderBuilder::trimesh_with_flags(Array[@core.Vec2], Array[(Int, Int, Int)], TriMeshFlags) -> Self?
 pub fn ColliderBuilder::user_data(Self, Int) -> Self
+pub fn ColliderBuilder::user_data128(Self, @core.UserData128) -> Self
 pub fn ColliderBuilder::voxelized_mesh(Array[@core.Vec2], Array[(Int, Int)], Float, FillMode) -> Self
 pub fn ColliderBuilder::voxels(@core.Vec2, Array[(Int, Int)]) -> Self
 pub fn ColliderBuilder::voxels_from_points(@core.Vec2, Array[@core.Vec2]) -> Self
@@ -443,6 +451,7 @@ pub struct ColliderBuilder3D {
   mut one_way_offset : Float?
   mut one_way_direction : Int
   mut active_events : ActiveEvents
+  mut user_data : @core.UserData128
   mut collision_groups : @dynamics.InteractionGroups
   mut friction : Float
   mut restitution : Float
@@ -483,6 +492,8 @@ pub fn ColliderBuilder3D::surface_velocity(Self, @core.Vec3) -> Self
 pub fn ColliderBuilder3D::translation(Self, @core.Vec3) -> Self
 pub fn ColliderBuilder3D::triangle(@core.Vec3, @core.Vec3, @core.Vec3) -> Self
 pub fn ColliderBuilder3D::trimesh(Array[@core.Vec3], Array[(Int, Int, Int)]) -> Self?
+pub fn ColliderBuilder3D::user_data(Self, Int) -> Self
+pub fn ColliderBuilder3D::user_data128(Self, @core.UserData128) -> Self
 pub fn ColliderBuilder3D::voxels_from_points(@core.Vec3, Array[@core.Vec3]) -> Self?
 
 pub struct ColliderChanges {

--- a/collision/spec.mbt
+++ b/collision/spec.mbt
@@ -871,6 +871,15 @@ pub fn ColliderBuilder::user_data(
 
 ///|
 #declaration_only
+pub fn ColliderBuilder::user_data128(
+  self : ColliderBuilder,
+  data : @core.UserData128,
+) -> ColliderBuilder {
+  ...
+}
+
+///|
+#declaration_only
 pub fn ColliderBuilder::enabled(
   self : ColliderBuilder,
   enabled : Bool,
@@ -1014,6 +1023,12 @@ pub fn Collider::user_data(self : Collider) -> Int {
 
 ///|
 #declaration_only
+pub fn Collider::user_data128(self : Collider) -> @core.UserData128 {
+  ...
+}
+
+///|
+#declaration_only
 pub fn Collider::is_enabled(self : Collider) -> Bool {
   ...
 }
@@ -1126,6 +1141,15 @@ pub fn Collider::set_contact_force_event_threshold(
 ///|
 #declaration_only
 pub fn Collider::set_user_data(self : Collider, data : Int) -> Collider {
+  ...
+}
+
+///|
+#declaration_only
+pub fn Collider::set_user_data128(
+  self : Collider,
+  data : @core.UserData128,
+) -> Collider {
   ...
 }
 

--- a/collision/voxelization.mbt
+++ b/collision/voxelization.mbt
@@ -177,7 +177,7 @@ fn collider_builder_with_shape(shape : Shape) -> ColliderBuilder {
     restitution_combine_rule: @dynamics.CoefficientCombineRule::Average,
     contact_skin: 0.0F,
     contact_force_event_threshold: 0.0F,
-    user_data: 0,
+    user_data: @core.UserData128::zero(),
     enabled: true,
   }
 }

--- a/core/moon.pkg.json
+++ b/core/moon.pkg.json
@@ -1,5 +1,6 @@
 {
   "import": [
-    "moonbitlang/core/math"
+    "moonbitlang/core/math",
+    "moonbitlang/core/uint64"
   ]
 }

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -212,6 +212,20 @@ pub fn SdpMat3::new(Float, Float, Float, Float, Float, Float) -> Self
 pub fn SdpMat3::transform_vec3(Self, Vec3) -> Vec3
 pub fn SdpMat3::zero() -> Self
 
+pub struct UserData128 {
+  hi : UInt64
+  lo : UInt64
+}
+pub fn UserData128::equals(Self, Self) -> Bool
+pub fn UserData128::from_int_truncate(Int) -> Self
+pub fn UserData128::from_parts(UInt64, UInt64) -> Self
+pub fn UserData128::from_u64(UInt64) -> Self
+pub fn UserData128::hi(Self) -> UInt64
+pub fn UserData128::lo(Self) -> UInt64
+pub fn UserData128::to_int_truncate(Self) -> Int
+pub fn UserData128::to_parts(Self) -> (UInt64, UInt64)
+pub fn UserData128::zero() -> Self
+
 #alias(TangentImpulse3)
 pub struct Vec2 {
   x : Float

--- a/core/user_data.mbt
+++ b/core/user_data.mbt
@@ -1,0 +1,71 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A Rapier-compatible `u128`-equivalent payload used by `RigidBody`/`Collider` user data.
+///
+/// Representation is `(hi, lo)` where the numeric value is `(hi << 64) | lo`.
+pub struct UserData128 {
+  hi : UInt64
+  lo : UInt64
+}
+
+///|
+pub fn UserData128::zero() -> UserData128 {
+  { hi: UInt64::default(), lo: UInt64::default() }
+}
+
+///|
+pub fn UserData128::from_parts(hi : UInt64, lo : UInt64) -> UserData128 {
+  { hi, lo }
+}
+
+///|
+pub fn UserData128::from_u64(value : UInt64) -> UserData128 {
+  { hi: UInt64::default(), lo: value }
+}
+
+///|
+/// Back-compat helper: interpret the given `Int` as an unsigned payload truncated to 64 bits,
+/// stored in the low 64 bits of this `UserData128`.
+pub fn UserData128::from_int_truncate(value : Int) -> UserData128 {
+  let lo = UInt64::extend_uint(value.reinterpret_as_uint())
+  UserData128::from_u64(lo)
+}
+
+///|
+/// Back-compat helper: return the low 64 bits truncated to `Int`.
+pub fn UserData128::to_int_truncate(self : UserData128) -> Int {
+  self.lo.to_int()
+}
+
+///|
+pub fn UserData128::hi(self : UserData128) -> UInt64 {
+  self.hi
+}
+
+///|
+pub fn UserData128::lo(self : UserData128) -> UInt64 {
+  self.lo
+}
+
+///|
+pub fn UserData128::to_parts(self : UserData128) -> (UInt64, UInt64) {
+  (self.hi, self.lo)
+}
+
+///|
+pub fn UserData128::equals(self : UserData128, other : UserData128) -> Bool {
+  UInt64::equal(self.hi, other.hi) && UInt64::equal(self.lo, other.lo)
+}

--- a/dynamics/moon.pkg.json
+++ b/dynamics/moon.pkg.json
@@ -1,6 +1,7 @@
 {
   "import": [
     "Milky2018/moon_rapier/core",
+    "moonbitlang/core/uint64",
     "moonbitlang/core/strconv"
   ],
   "test-import": [

--- a/dynamics/pkg.generated.mbti
+++ b/dynamics/pkg.generated.mbti
@@ -939,6 +939,7 @@ pub fn RevoluteJointBuilder3::softness(Self, SpringCoefficients) -> Self
 
 pub struct RigidBody {
   mut ids : RigidBodyIds
+  mut user_data : @core.UserData128
   position : RigidBodyPosition
   mut body_type : RigidBodyType
   mut locked_translations : Bool
@@ -1043,11 +1044,15 @@ pub fn RigidBody::set_position(Self, @core.Isometry2, Bool) -> Self
 pub fn RigidBody::set_rotation(Self, @core.Rot2, Bool) -> Self
 pub fn RigidBody::set_soft_ccd_prediction(Self, Float) -> Self
 pub fn RigidBody::set_translation(Self, @core.Vec2, Bool) -> Self
+pub fn RigidBody::set_user_data(Self, Int) -> Self
+pub fn RigidBody::set_user_data128(Self, @core.UserData128) -> Self
 pub fn RigidBody::set_vels(Self, RigidBodyVelocity, Bool) -> Self
 pub fn RigidBody::sleep(Self) -> Self
 pub fn RigidBody::soft_ccd_prediction(Self) -> Float
 pub fn RigidBody::translation(Self) -> @core.Vec2
 pub fn RigidBody::update_effective_force_and_torque(Self, @core.Vec2) -> Self
+pub fn RigidBody::user_data(Self) -> Int
+pub fn RigidBody::user_data128(Self) -> @core.UserData128
 pub fn RigidBody::velocity_at_point(Self, @core.Vec2) -> @core.Vec2
 pub fn RigidBody::vels(Self) -> RigidBodyVelocity
 pub fn RigidBody::wake_up(Self, Bool) -> Self
@@ -1055,6 +1060,7 @@ pub fn RigidBody::world_com(Self) -> @core.Vec2
 
 pub struct RigidBody3D {
   body_type : RigidBodyType
+  mut user_data : @core.UserData128
   mut position : @core.Isometry3
   mut next_position : @core.Isometry3
   mut velocity : RigidBodyVelocity3D
@@ -1100,10 +1106,14 @@ pub fn RigidBody3D::set_next_kinematic_rotation(Self, @core.Quat) -> Unit
 pub fn RigidBody3D::set_next_kinematic_translation(Self, @core.Vec3) -> Unit
 pub fn RigidBody3D::set_rotation(Self, @core.Quat) -> Unit
 pub fn RigidBody3D::set_translation(Self, @core.Vec3) -> Unit
+pub fn RigidBody3D::set_user_data(Self, Int) -> Unit
+pub fn RigidBody3D::set_user_data128(Self, @core.UserData128) -> Unit
 pub fn RigidBody3D::soft_ccd_prediction(Self) -> Float
 pub fn RigidBody3D::translation(Self) -> @core.Vec3
 pub fn RigidBody3D::update_kinematic_velocities(Self, Float) -> Unit
 pub fn RigidBody3D::update_sleep(Self, Float, Float) -> Unit
+pub fn RigidBody3D::user_data(Self) -> Int
+pub fn RigidBody3D::user_data128(Self) -> @core.UserData128
 pub fn RigidBody3D::wake_up(Self) -> Unit
 pub fn RigidBody3D::world_com(Self) -> @core.Vec3
 
@@ -1167,6 +1177,7 @@ pub struct RigidBodyBuilder {
   mut ccd_enabled : Bool
   mut soft_ccd_prediction : Float
   mut dominance_group : Int
+  mut user_data : @core.UserData128
 }
 pub fn RigidBodyBuilder::additional_mass(Self, Float) -> Self
 pub fn RigidBodyBuilder::additional_mass_properties(Self, RigidBodyAdditionalMassProps) -> Self
@@ -1200,6 +1211,8 @@ pub fn RigidBodyBuilder::rotation(Self, @core.Rot2) -> Self
 pub fn RigidBodyBuilder::sleeping(Self, Bool) -> Self
 pub fn RigidBodyBuilder::soft_ccd_prediction(Self, Float) -> Self
 pub fn RigidBodyBuilder::translation(Self, @core.Vec2) -> Self
+pub fn RigidBodyBuilder::user_data(Self, Int) -> Self
+pub fn RigidBodyBuilder::user_data128(Self, @core.UserData128) -> Self
 
 pub struct RigidBodyBuilder3 {
   inner : RigidBodyBuilder
@@ -1245,6 +1258,7 @@ pub struct RigidBodyBuilder3D {
   mut gravity_scale : Float
   mut mass_properties : @core.MassProperties3
   mut can_sleep : Bool
+  mut user_data : @core.UserData128
 }
 pub fn RigidBodyBuilder3D::angular_damping(Self, Float) -> Self
 pub fn RigidBodyBuilder3D::angvel(Self, @core.Vec3) -> Self
@@ -1267,6 +1281,8 @@ pub fn RigidBodyBuilder3D::rotation(Self, @core.Quat) -> Self
 pub fn RigidBodyBuilder3D::rotation_scaled_axis(Self, @core.Vec3) -> Self
 pub fn RigidBodyBuilder3D::soft_ccd_prediction(Self, Float) -> Self
 pub fn RigidBodyBuilder3D::translation(Self, @core.Vec3) -> Self
+pub fn RigidBodyBuilder3D::user_data(Self, Int) -> Self
+pub fn RigidBodyBuilder3D::user_data128(Self, @core.UserData128) -> Self
 
 pub struct RigidBodyCcd {
   ccd_thickness : Float

--- a/dynamics/rigid_body.mbt
+++ b/dynamics/rigid_body.mbt
@@ -817,6 +817,7 @@ pub fn RigidBodyAdditionalMassProps::mass_properties(
 ///|
 pub struct RigidBody {
   mut ids : RigidBodyIds
+  mut user_data : @core.UserData128
   position : RigidBodyPosition
   mut body_type : RigidBodyType
   mut locked_translations : Bool
@@ -1626,6 +1627,7 @@ pub struct RigidBodyBuilder {
   mut ccd_enabled : Bool
   mut soft_ccd_prediction : @core.Real
   mut dominance_group : Int
+  mut user_data : @core.UserData128
 }
 
 ///|
@@ -1648,6 +1650,7 @@ pub fn RigidBodyBuilder::new(body_type : RigidBodyType) -> RigidBodyBuilder {
     ccd_enabled: false,
     soft_ccd_prediction: 0.0F,
     dominance_group: 0,
+    user_data: @core.UserData128::zero(),
   }
 }
 
@@ -1789,6 +1792,24 @@ pub fn RigidBodyBuilder::dominance_group(
 }
 
 ///|
+pub fn RigidBodyBuilder::user_data(
+  self : RigidBodyBuilder,
+  data : Int,
+) -> RigidBodyBuilder {
+  self.user_data = @core.UserData128::from_int_truncate(data)
+  self
+}
+
+///|
+pub fn RigidBodyBuilder::user_data128(
+  self : RigidBodyBuilder,
+  data : @core.UserData128,
+) -> RigidBodyBuilder {
+  self.user_data = data
+  self
+}
+
+///|
 pub fn RigidBodyBuilder::can_sleep(
   self : RigidBodyBuilder,
   can_sleep : Bool,
@@ -1924,6 +1945,7 @@ pub fn RigidBodyBuilder::build(self : RigidBodyBuilder) -> RigidBody {
   forces.gravity_scale = self.gravity_scale
   let mut rb = {
     ids: RigidBodyIds::default(),
+    user_data: self.user_data,
     position: pos,
     body_type: self.body_type,
     locked_translations: self.lock_translations,
@@ -2294,6 +2316,19 @@ fn parse_real_value(text : String) -> @core.Real {
 }
 
 ///|
+fn parse_u64_value(text : String) -> UInt64 {
+  let result : Result[UInt64, @strconv.StrConvError] = try? @strconv.parse_uint64(
+    text[:],
+    base=10,
+  )
+  if result is Ok(value) {
+    value
+  } else {
+    UInt64::default()
+  }
+}
+
+///|
 fn parse_bool_value(text : String) -> Bool {
   text == "1"
 }
@@ -2400,6 +2435,12 @@ pub fn RigidBodySet::serialize(self : RigidBodySet) -> String {
       sb.write_object(if body.ccd.ccd_enabled { 1 } else { 0 })
       sb.write_char(',')
       sb.write_object(body.ccd.soft_ccd_prediction)
+      sb.write_char(',')
+      sb.write_object(body.user_data.to_int_truncate())
+      sb.write_char(',')
+      sb.write_string(body.user_data.hi().to_string())
+      sb.write_char(',')
+      sb.write_string(body.user_data.lo().to_string())
     } else {
       sb.write_char('N')
     }
@@ -2629,6 +2670,18 @@ pub fn RigidBodySet::deserialize(data : String) -> RigidBodySet {
           } else {
             0.0F
           }
+          let user_data_int = if fields.length() > extras_start + 15 {
+            parse_int_value(fields[extras_start + 15])
+          } else {
+            0
+          }
+          let user_data = if fields.length() > extras_start + 17 {
+            let hi = parse_u64_value(fields[extras_start + 16])
+            let lo = parse_u64_value(fields[extras_start + 17])
+            @core.UserData128::from_parts(hi, lo)
+          } else {
+            @core.UserData128::from_int_truncate(user_data_int)
+          }
           let position = @core.Isometry2::new(
             @core.Vec2::new(tx, ty),
             @core.Rot2::from_angle(rot),
@@ -2640,6 +2693,7 @@ pub fn RigidBodySet::deserialize(data : String) -> RigidBodySet {
           let rb_pos = RigidBodyPosition::new(position, next_position)
           let body : RigidBody = {
             ids: RigidBodyIds::default(),
+            user_data,
             position: rb_pos,
             body_type,
             locked_translations,
@@ -2702,6 +2756,31 @@ pub fn RigidBody::activation_mut(self : RigidBody) -> RigidBodyActivation {
 ///|
 pub fn RigidBody::effective_active_set_offset(self : RigidBody) -> Int {
   self.ids.active_set_id
+}
+
+///|
+pub fn RigidBody::user_data(self : RigidBody) -> Int {
+  self.user_data.to_int_truncate()
+}
+
+///|
+pub fn RigidBody::user_data128(self : RigidBody) -> @core.UserData128 {
+  self.user_data
+}
+
+///|
+pub fn RigidBody::set_user_data(self : RigidBody, data : Int) -> RigidBody {
+  self.user_data = @core.UserData128::from_int_truncate(data)
+  self
+}
+
+///|
+pub fn RigidBody::set_user_data128(
+  self : RigidBody,
+  data : @core.UserData128,
+) -> RigidBody {
+  self.user_data = data
+  self
 }
 
 ///|

--- a/dynamics/rigid_body3d.mbt
+++ b/dynamics/rigid_body3d.mbt
@@ -179,6 +179,7 @@ pub fn RigidBodyActivation3D::update(
 ///|
 pub struct RigidBody3D {
   body_type : RigidBodyType
+  mut user_data : @core.UserData128
   mut position : @core.Isometry3
   // Target pose used by kinematic position-based bodies.
   mut next_position : @core.Isometry3
@@ -266,6 +267,29 @@ pub fn RigidBody3D::set_angvel(self : RigidBody3D, w : @core.Vec3) -> Unit {
 ///|
 pub fn RigidBody3D::body_type(self : RigidBody3D) -> RigidBodyType {
   self.body_type
+}
+
+///|
+pub fn RigidBody3D::user_data(self : RigidBody3D) -> Int {
+  self.user_data.to_int_truncate()
+}
+
+///|
+pub fn RigidBody3D::user_data128(self : RigidBody3D) -> @core.UserData128 {
+  self.user_data
+}
+
+///|
+pub fn RigidBody3D::set_user_data(self : RigidBody3D, data : Int) -> Unit {
+  self.user_data = @core.UserData128::from_int_truncate(data)
+}
+
+///|
+pub fn RigidBody3D::set_user_data128(
+  self : RigidBody3D,
+  data : @core.UserData128,
+) -> Unit {
+  self.user_data = data
 }
 
 ///|
@@ -608,6 +632,7 @@ pub struct RigidBodyBuilder3D {
   mut gravity_scale : @core.Real
   mut mass_properties : @core.MassProperties3
   mut can_sleep : Bool
+  mut user_data : @core.UserData128
 }
 
 ///|
@@ -635,6 +660,7 @@ pub fn RigidBodyBuilder3D::dynamic() -> RigidBodyBuilder3D {
       @core.Vec3::zero(),
     ),
     can_sleep: true,
+    user_data: @core.UserData128::zero(),
   }
 }
 
@@ -671,6 +697,24 @@ pub fn RigidBodyBuilder3D::can_sleep(
   can_sleep : Bool,
 ) -> RigidBodyBuilder3D {
   self.can_sleep = can_sleep
+  self
+}
+
+///|
+pub fn RigidBodyBuilder3D::user_data(
+  self : RigidBodyBuilder3D,
+  data : Int,
+) -> RigidBodyBuilder3D {
+  self.user_data = @core.UserData128::from_int_truncate(data)
+  self
+}
+
+///|
+pub fn RigidBodyBuilder3D::user_data128(
+  self : RigidBodyBuilder3D,
+  data : @core.UserData128,
+) -> RigidBodyBuilder3D {
+  self.user_data = data
   self
 }
 
@@ -820,6 +864,7 @@ pub fn RigidBodyBuilder3D::build(self : RigidBodyBuilder3D) -> RigidBody3D {
   let pos = @core.Isometry3::new(self.translation, self.rotation)
   {
     body_type: self.body_type,
+    user_data: self.user_data,
     position: pos,
     next_position: pos,
     velocity: { linvel: self.linvel, angvel: self.angvel },

--- a/dynamics/spec.mbt
+++ b/dynamics/spec.mbt
@@ -820,6 +820,24 @@ pub fn RigidBodyBuilder::dominance_group(
 
 ///|
 #declaration_only
+pub fn RigidBodyBuilder::user_data(
+  self : RigidBodyBuilder,
+  data : Int,
+) -> RigidBodyBuilder {
+  ...
+}
+
+///|
+#declaration_only
+pub fn RigidBodyBuilder::user_data128(
+  self : RigidBodyBuilder,
+  data : @core.UserData128,
+) -> RigidBodyBuilder {
+  ...
+}
+
+///|
+#declaration_only
 pub fn RigidBodyBuilder::build(self : RigidBodyBuilder) -> RigidBody {
   ...
 }
@@ -2420,6 +2438,33 @@ pub fn RigidBody::set_next_kinematic_rotation(
 pub fn RigidBody::set_next_kinematic_position(
   self : RigidBody,
   position : @core.Isometry2,
+) -> RigidBody {
+  ...
+}
+
+///|
+#declaration_only
+pub fn RigidBody::user_data(self : RigidBody) -> Int {
+  ...
+}
+
+///|
+#declaration_only
+pub fn RigidBody::user_data128(self : RigidBody) -> @core.UserData128 {
+  ...
+}
+
+///|
+#declaration_only
+pub fn RigidBody::set_user_data(self : RigidBody, data : Int) -> RigidBody {
+  ...
+}
+
+///|
+#declaration_only
+pub fn RigidBody::set_user_data128(
+  self : RigidBody,
+  data : @core.UserData128,
 ) -> RigidBody {
   ...
 }

--- a/dynamics/user_data_test.mbt
+++ b/dynamics/user_data_test.mbt
@@ -1,0 +1,34 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "rigid body user_data128 roundtrip through RigidBodySet serialize/deserialize" {
+  let bodies = RigidBodySet::new()
+  let data = @core.UserData128::from_parts(42UL, 99UL)
+  let h = bodies.insert(RigidBodyBuilder::dynamic().user_data128(data).build())
+  let snapshot = bodies.serialize()
+  let bodies2 = RigidBodySet::deserialize(snapshot)
+  if bodies2.get(h) is Some(rb) {
+    inspect(rb.user_data128().equals(data), content="true")
+  } else {
+    inspect(false, content="true")
+  }
+}
+
+///|
+test "rigid body 3D user_data128 stored on build" {
+  let data = @core.UserData128::from_parts(1UL, 2UL)
+  let rb = RigidBodyBuilder3D::dynamic().user_data128(data).build()
+  inspect(rb.user_data128().equals(data), content="true")
+}


### PR DESCRIPTION
Fixes #11.\n\n- Add @core.UserData128 (hi/lo UInt64) as a u128-equivalent payload.\n- Expose user_data128 accessors/builders on 2D+3D RigidBody and Collider.\n- Keep existing Int-based user_data APIs for backward compatibility (truncate to low 64 bits).\n- Extend serialize/deserialize snapshots to preserve full 128-bit user data (back-compatible).\n- Add regression tests for roundtrip + 3D builder storage.