### PR TITLE
Fix #12: QueryPipeline operates on external sets

### DIFF
--- a/collision/pkg.generated.mbti
+++ b/collision/pkg.generated.mbti
@@ -981,67 +981,60 @@ pub fn QueryFilterFlags::toggle(Self, Self) -> Self
 pub fn QueryFilterFlags::union(Self, Self) -> Self
 
 pub struct QueryPipeline {
-  dispatcher : Unit
   bvh : Bvh
   filter : QueryFilter
-  bodies : @dynamics.RigidBodySet
-  colliders : ColliderSet
 }
-pub fn QueryPipeline::cast_ray(Self, Ray, Float, Bool) -> (ColliderHandle, Float)?
-pub fn QueryPipeline::cast_ray_and_get_normal(Self, Ray, Float, Bool) -> (ColliderHandle, RayIntersection)?
-pub fn QueryPipeline::cast_shape(Self, @core.Isometry2, @core.Vec2, Shape, ShapeCastOptions) -> (ColliderHandle, ShapeCastHit)?
-pub fn QueryPipeline::cast_shape_nonlinear(Self, NonlinearRigidMotion, Shape, Float, Float, Bool) -> (ColliderHandle, ShapeCastHit)?
-pub fn QueryPipeline::collider(Self, ColliderHandle) -> Collider?
-pub fn QueryPipeline::intersect_aabb_conservative(Self, @core.Aabb) -> Array[ColliderHandle]
-pub fn QueryPipeline::intersect_point(Self, @core.Vec2) -> Array[ColliderHandle]
-pub fn QueryPipeline::intersect_ray(Self, Ray, Float, Bool) -> Array[(ColliderHandle, RayIntersection)]
-pub fn QueryPipeline::intersect_shape(Self, @core.Isometry2, Shape) -> Array[ColliderHandle]
+pub fn QueryPipeline::cast_ray(Self, @dynamics.RigidBodySet, ColliderSet, Ray, Float, Bool) -> (ColliderHandle, Float)?
+pub fn QueryPipeline::cast_ray_and_get_normal(Self, @dynamics.RigidBodySet, ColliderSet, Ray, Float, Bool) -> (ColliderHandle, RayIntersection)?
+pub fn QueryPipeline::cast_shape(Self, @dynamics.RigidBodySet, ColliderSet, @core.Isometry2, @core.Vec2, Shape, ShapeCastOptions) -> (ColliderHandle, ShapeCastHit)?
+pub fn QueryPipeline::cast_shape_nonlinear(Self, @dynamics.RigidBodySet, ColliderSet, NonlinearRigidMotion, Shape, Float, Float, Bool) -> (ColliderHandle, ShapeCastHit)?
+pub fn QueryPipeline::collider(Self, ColliderSet, ColliderHandle) -> Collider?
+pub fn QueryPipeline::intersect_aabb_conservative(Self, @dynamics.RigidBodySet, ColliderSet, @core.Aabb) -> Array[ColliderHandle]
+pub fn QueryPipeline::intersect_point(Self, @dynamics.RigidBodySet, ColliderSet, @core.Vec2) -> Array[ColliderHandle]
+pub fn QueryPipeline::intersect_ray(Self, @dynamics.RigidBodySet, ColliderSet, Ray, Float, Bool) -> Array[(ColliderHandle, RayIntersection)]
+pub fn QueryPipeline::intersect_shape(Self, @dynamics.RigidBodySet, ColliderSet, @core.Isometry2, Shape) -> Array[ColliderHandle]
 pub fn QueryPipeline::new(QueryFilter, @dynamics.RigidBodySet, ColliderSet) -> Self
 pub fn QueryPipeline::new3(QueryFilter, @dynamics.RigidBodySet3, ColliderSet3) -> Self
-pub fn QueryPipeline::project_point(Self, @core.Vec2, Float, Bool) -> (ColliderHandle, PointProjection)?
-pub fn QueryPipeline::project_point_and_get_feature(Self, @core.Vec2, Float, Bool) -> (ColliderHandle, PointProjection, FeatureId)?
-pub fn QueryPipeline::rigid_body(Self, @dynamics.RigidBodyHandle) -> @dynamics.RigidBody?
-pub fn QueryPipeline::update(Self) -> Unit
+pub fn QueryPipeline::project_point(Self, @dynamics.RigidBodySet, ColliderSet, @core.Vec2, Float, Bool) -> (ColliderHandle, PointProjection)?
+pub fn QueryPipeline::project_point_and_get_feature(Self, @dynamics.RigidBodySet, ColliderSet, @core.Vec2, Float, Bool) -> (ColliderHandle, PointProjection, FeatureId)?
+pub fn QueryPipeline::rigid_body(Self, @dynamics.RigidBodySet, @dynamics.RigidBodyHandle) -> @dynamics.RigidBody?
+pub fn QueryPipeline::update(Self, @dynamics.RigidBodySet, ColliderSet) -> Unit
 pub fn QueryPipeline::with_filter(Self, QueryFilter) -> Self
 
 pub struct QueryPipeline3DReal {
   filter : QueryFilter3DReal
-  bodies : @dynamics.RigidBodySet3D
-  colliders : ColliderSet3D
   mut cached_aabbs : Array[@core.Aabb3?]
 }
-pub fn QueryPipeline3DReal::cast_ray(Self, Ray3, Float, Bool) -> (ColliderHandle3D, Float)?
-pub fn QueryPipeline3DReal::cast_ray_and_get_normal(Self, Ray3, Float, Bool) -> (ColliderHandle3D, RayIntersection3)?
-pub fn QueryPipeline3DReal::cast_ray_and_get_normal_and_feature(Self, Ray3, Float, Bool) -> (ColliderHandle3D, RayIntersection3Feature)?
-pub fn QueryPipeline3DReal::cast_ray_and_get_voxel_key(Self, Ray3, Float, Bool) -> (ColliderHandle3D, RayIntersection3, (Int, Int, Int))?
-pub fn QueryPipeline3DReal::cast_shape(Self, @core.Isometry3, @core.Vec3, Shape3D, ShapeCastOptions3) -> (ColliderHandle3D, ShapeCastHit3)?
-pub fn QueryPipeline3DReal::collider(Self, ColliderHandle3D) -> Collider3D?
-pub fn QueryPipeline3DReal::intersect_aabb_conservative(Self, @core.Aabb3) -> Array[ColliderHandle3D]
-pub fn QueryPipeline3DReal::intersect_point(Self, @core.Vec3) -> Array[ColliderHandle3D]
-pub fn QueryPipeline3DReal::intersect_ray(Self, Ray3, Float, Bool) -> Array[(ColliderHandle3D, RayIntersection3Feature)]
+pub fn QueryPipeline3DReal::cast_ray(Self, @dynamics.RigidBodySet3D, ColliderSet3D, Ray3, Float, Bool) -> (ColliderHandle3D, Float)?
+pub fn QueryPipeline3DReal::cast_ray_and_get_normal(Self, @dynamics.RigidBodySet3D, ColliderSet3D, Ray3, Float, Bool) -> (ColliderHandle3D, RayIntersection3)?
+pub fn QueryPipeline3DReal::cast_ray_and_get_normal_and_feature(Self, @dynamics.RigidBodySet3D, ColliderSet3D, Ray3, Float, Bool) -> (ColliderHandle3D, RayIntersection3Feature)?
+pub fn QueryPipeline3DReal::cast_ray_and_get_voxel_key(Self, @dynamics.RigidBodySet3D, ColliderSet3D, Ray3, Float, Bool) -> (ColliderHandle3D, RayIntersection3, (Int, Int, Int))?
+pub fn QueryPipeline3DReal::cast_shape(Self, @dynamics.RigidBodySet3D, ColliderSet3D, @core.Isometry3, @core.Vec3, Shape3D, ShapeCastOptions3) -> (ColliderHandle3D, ShapeCastHit3)?
+pub fn QueryPipeline3DReal::collider(Self, ColliderSet3D, ColliderHandle3D) -> Collider3D?
+pub fn QueryPipeline3DReal::intersect_aabb_conservative(Self, @dynamics.RigidBodySet3D, ColliderSet3D, @core.Aabb3) -> Array[ColliderHandle3D]
+pub fn QueryPipeline3DReal::intersect_point(Self, @dynamics.RigidBodySet3D, ColliderSet3D, @core.Vec3) -> Array[ColliderHandle3D]
+pub fn QueryPipeline3DReal::intersect_ray(Self, @dynamics.RigidBodySet3D, ColliderSet3D, Ray3, Float, Bool) -> Array[(ColliderHandle3D, RayIntersection3Feature)]
 pub fn QueryPipeline3DReal::new(QueryFilter3DReal, @dynamics.RigidBodySet3D, ColliderSet3D) -> Self
-pub fn QueryPipeline3DReal::project_point(Self, @core.Vec3, Float, Bool) -> (ColliderHandle3D, PointProjection3)?
-pub fn QueryPipeline3DReal::rigid_body(Self, @dynamics.RigidBodyHandle) -> @dynamics.RigidBody3D?
-pub fn QueryPipeline3DReal::rigid_body_mut(Self, @dynamics.RigidBodyHandle) -> @dynamics.RigidBody3D?
-pub fn QueryPipeline3DReal::update(Self) -> Unit
+pub fn QueryPipeline3DReal::project_point(Self, @dynamics.RigidBodySet3D, ColliderSet3D, @core.Vec3, Float, Bool) -> (ColliderHandle3D, PointProjection3)?
+pub fn QueryPipeline3DReal::rigid_body(Self, @dynamics.RigidBodySet3D, @dynamics.RigidBodyHandle) -> @dynamics.RigidBody3D?
+pub fn QueryPipeline3DReal::rigid_body_mut(Self, @dynamics.RigidBodySet3D, @dynamics.RigidBodyHandle) -> @dynamics.RigidBody3D?
+pub fn QueryPipeline3DReal::update(Self, @dynamics.RigidBodySet3D, ColliderSet3D) -> Unit
 pub fn QueryPipeline3DReal::with_filter(Self, QueryFilter3DReal) -> Self
 
 pub struct QueryPipelineMut {
-  mut dispatcher : Unit
-  mut bvh : Bvh
   pipeline : QueryPipeline
 }
 pub fn QueryPipelineMut::as_ref(Self) -> QueryPipeline
 pub fn QueryPipelineMut::new(QueryFilter, @dynamics.RigidBodySet, ColliderSet) -> Self
 pub fn QueryPipelineMut::new3(QueryFilter, @dynamics.RigidBodySet3, ColliderSet3) -> Self
-pub fn QueryPipelineMut::update(Self) -> Unit
+pub fn QueryPipelineMut::update(Self, @dynamics.RigidBodySet, ColliderSet) -> Unit
 
 pub struct QueryPipelineMut3DReal {
   pipeline : QueryPipeline3DReal
 }
 pub fn QueryPipelineMut3DReal::as_ref(Self) -> QueryPipeline3DReal
 pub fn QueryPipelineMut3DReal::new(QueryFilter3DReal, @dynamics.RigidBodySet3D, ColliderSet3D) -> Self
-pub fn QueryPipelineMut3DReal::update(Self) -> Unit
+pub fn QueryPipelineMut3DReal::update(Self, @dynamics.RigidBodySet3D, ColliderSet3D) -> Unit
 
 pub struct Ray {
   origin : @core.Vec2

--- a/collision/query_pipeline.mbt
+++ b/collision/query_pipeline.mbt
@@ -446,20 +446,13 @@ pub fn Bvh::aabbs(self : Bvh) -> Array[@core.Aabb?] {
 
 ///|
 pub struct QueryPipeline {
-  /// A placeholder query dispatcher. Unlike Rapier, this port hardcodes the supported
-  /// shape queries, so this is currently only provided for pub-surface parity.
-  dispatcher : Unit
   /// Conservative AABB cache used by this QueryPipeline.
   bvh : Bvh
   filter : QueryFilter
-  bodies : @dynamics.RigidBodySet
-  colliders : ColliderSet
 }
 
 ///|
 pub struct QueryPipelineMut {
-  mut dispatcher : Unit
-  mut bvh : Bvh
   pipeline : QueryPipeline
 }
 
@@ -625,6 +618,7 @@ pub fn QueryPipeline::new(
   bodies : @dynamics.RigidBodySet,
   colliders : ColliderSet,
 ) -> QueryPipeline {
+  colliders.sync_with_bodies(bodies)
   let aabbs : Array[@core.Aabb?] = []
   for i in 0..<colliders.colliders.length() {
     if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
@@ -633,7 +627,7 @@ pub fn QueryPipeline::new(
       aabbs.push(None)
     }
   }
-  { dispatcher: (), bvh: Bvh::new(aabbs), filter, bodies, colliders }
+  { bvh: Bvh::new(aabbs), filter }
 }
 
 ///|
@@ -646,12 +640,15 @@ pub fn QueryPipeline::new3(
 }
 
 ///|
-pub fn QueryPipeline::update(self : QueryPipeline) -> Unit {
-  // Refresh collider world-space state and cached AABBs so scene queries see the latest positions.
-  self.colliders.sync_with_bodies(self.bodies)
+pub fn QueryPipeline::update(
+  self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
+) -> Unit {
+  colliders.sync_with_bodies(bodies)
   self.bvh.aabbs.clear()
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
       self.bvh.aabbs.push(Some(compute_collider_aabb(collider)))
     } else {
       self.bvh.aabbs.push(None)
@@ -664,13 +661,7 @@ pub fn QueryPipeline::with_filter(
   self : QueryPipeline,
   filter : QueryFilter,
 ) -> QueryPipeline {
-  {
-    dispatcher: self.dispatcher,
-    bvh: self.bvh,
-    filter,
-    bodies: self.bodies,
-    colliders: self.colliders,
-  }
+  { bvh: self.bvh, filter }
 }
 
 ///|
@@ -680,7 +671,7 @@ pub fn QueryPipelineMut::new(
   colliders : ColliderSet,
 ) -> QueryPipelineMut {
   let pipeline = QueryPipeline::new(filter, bodies, colliders)
-  { dispatcher: pipeline.dispatcher, bvh: pipeline.bvh, pipeline }
+  { pipeline, }
 }
 
 ///|
@@ -698,10 +689,12 @@ pub fn QueryPipelineMut::as_ref(self : QueryPipelineMut) -> QueryPipeline {
 }
 
 ///|
-pub fn QueryPipelineMut::update(self : QueryPipelineMut) -> Unit {
-  self.pipeline.update()
-  self.dispatcher = self.pipeline.dispatcher
-  self.bvh = self.pipeline.bvh
+pub fn QueryPipelineMut::update(
+  self : QueryPipelineMut,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
+) -> Unit {
+  self.pipeline.update(bodies, colliders)
 }
 
 ///|
@@ -1158,11 +1151,14 @@ fn ray_intersect_capsule_oriented_and_get_normal(
 ///|
 pub fn QueryPipeline::cast_ray(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   ray : Ray,
   max_toi : @core.Real,
   solid : Bool,
 ) -> (ColliderHandle, @core.Real)? {
-  if self.cast_ray_and_get_normal(ray, max_toi, solid) is Some(hit) {
+  if self.cast_ray_and_get_normal(bodies, colliders, ray, max_toi, solid)
+    is Some(hit) {
     Some((hit.0, hit.1.toi))
   } else {
     None
@@ -1172,16 +1168,18 @@ pub fn QueryPipeline::cast_ray(
 ///|
 pub fn QueryPipeline::cast_ray_and_get_normal(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   ray : Ray,
   max_toi : @core.Real,
   solid : Bool,
 ) -> (ColliderHandle, RayIntersection)? {
   let max_dist = if max_toi < 0.0F { 0.0F } else { max_toi }
   let mut best : (ColliderHandle, RayIntersection)? = None
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
-      let handle = ColliderHandle::new(i, self.colliders.generations[i])
-      if !self.filter.passes(self.bodies, handle, collider) {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+      let handle = ColliderHandle::new(i, colliders.generations[i])
+      if !self.filter.passes(bodies, handle, collider) {
         continue
       }
       let pos = collider.world_translation
@@ -1211,16 +1209,18 @@ pub fn QueryPipeline::cast_ray_and_get_normal(
 ///|
 pub fn QueryPipeline::intersect_ray(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   ray : Ray,
   max_toi : @core.Real,
   solid : Bool,
 ) -> Array[(ColliderHandle, RayIntersection)] {
   let max_dist = if max_toi < 0.0F { 0.0F } else { max_toi }
   let results : Array[(ColliderHandle, RayIntersection)] = []
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
-      let handle = ColliderHandle::new(i, self.colliders.generations[i])
-      if !self.filter.passes(self.bodies, handle, collider) {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+      let handle = ColliderHandle::new(i, colliders.generations[i])
+      if !self.filter.passes(bodies, handle, collider) {
         continue
       }
       let pos = collider.world_translation
@@ -1750,6 +1750,8 @@ fn shape_cast_against_capsule(
 ///|
 pub fn QueryPipeline::cast_shape(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   shape_pos : @core.Isometry2,
   shape_vel : @core.Vec2,
   shape : Shape,
@@ -1776,10 +1778,10 @@ pub fn QueryPipeline::cast_shape(
     Shape::Compound(_) => shape
   }
   let mut best : (ColliderHandle, ShapeCastHit)? = None
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
-      let handle = ColliderHandle::new(i, self.colliders.generations[i])
-      if !self.filter.passes(self.bodies, handle, collider) {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+      let handle = ColliderHandle::new(i, colliders.generations[i])
+      if !self.filter.passes(bodies, handle, collider) {
         continue
       }
       fn best_hit(
@@ -2139,6 +2141,8 @@ pub fn QueryPipeline::cast_shape(
 ///|
 pub fn QueryPipeline::cast_shape_nonlinear(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   shape_motion : NonlinearRigidMotion,
   shape : Shape,
   start_time : @core.Real,
@@ -2449,10 +2453,10 @@ pub fn QueryPipeline::cast_shape_nonlinear(
   let c1 = shape_motion.pose_at_time(end_time).translation
   let sweep_aabb = swept_center_aabb(c0, c1, radius)
   let mut best : (ColliderHandle, ShapeCastHit)? = None
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
-      let handle = ColliderHandle::new(i, self.colliders.generations[i])
-      if !self.filter.passes(self.bodies, handle, collider) {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+      let handle = ColliderHandle::new(i, colliders.generations[i])
+      if !self.filter.passes(bodies, handle, collider) {
         continue
       }
       // AABB prefilter using the cached collider AABB (Rapier parity).
@@ -2524,17 +2528,21 @@ pub fn QueryPipeline::cast_shape_nonlinear(
 ///|
 pub fn QueryPipeline::collider(
   self : QueryPipeline,
+  colliders : ColliderSet,
   handle : ColliderHandle,
 ) -> Collider? {
-  self.colliders.get(handle)
+  self |> ignore
+  colliders.get(handle)
 }
 
 ///|
 pub fn QueryPipeline::rigid_body(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
   handle : @dynamics.RigidBodyHandle,
 ) -> @dynamics.RigidBody? {
-  self.bodies.get(handle)
+  self |> ignore
+  bodies.get(handle)
 }
 
 ///|
@@ -3010,15 +3018,17 @@ fn compute_query_shape_aabb(
 ///|
 pub fn QueryPipeline::intersect_shape(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   shape_pos : @core.Isometry2,
   shape : Shape,
 ) -> Array[ColliderHandle] {
   let shape_aabb = compute_query_shape_aabb(shape_pos, shape)
   let results : Array[ColliderHandle] = []
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
-      let handle = ColliderHandle::new(i, self.colliders.generations[i])
-      if !self.filter.passes(self.bodies, handle, collider) {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+      let handle = ColliderHandle::new(i, colliders.generations[i])
+      if !self.filter.passes(bodies, handle, collider) {
         continue
       }
       if i < self.bvh.aabbs.length() && self.bvh.aabbs[i] is Some(co_aabb) {
@@ -3044,13 +3054,15 @@ pub fn QueryPipeline::intersect_shape(
 ///|
 pub fn QueryPipeline::intersect_aabb_conservative(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   aabb : @core.Aabb,
 ) -> Array[ColliderHandle] {
   let result : Array[ColliderHandle] = []
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
-      let handle = ColliderHandle::new(i, self.colliders.generations[i])
-      if !self.filter.passes(self.bodies, handle, collider) {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+      let handle = ColliderHandle::new(i, colliders.generations[i])
+      if !self.filter.passes(bodies, handle, collider) {
         continue
       }
       // Use the cached AABB from pipeline creation time (Rapier parity).
@@ -3939,6 +3951,8 @@ fn project_point_on_shape_and_get_feature(
 ///|
 pub fn QueryPipeline::project_point(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   point : @core.Vec2,
   max_dist : @core.Real,
   solid : Bool,
@@ -3946,10 +3960,10 @@ pub fn QueryPipeline::project_point(
   // Rapier keeps this parameter for API consistency, but doesn't use it.
   max_dist |> ignore
   let mut best : (ColliderHandle, PointProjection, @core.Real)? = None
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
-      let handle = ColliderHandle::new(i, self.colliders.generations[i])
-      if !self.filter.passes(self.bodies, handle, collider) {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+      let handle = ColliderHandle::new(i, colliders.generations[i])
+      if !self.filter.passes(bodies, handle, collider) {
         continue
       }
       let projection = project_point_on_shape(
@@ -3980,6 +3994,8 @@ pub fn QueryPipeline::project_point(
 ///|
 pub fn QueryPipeline::project_point_and_get_feature(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   point : @core.Vec2,
   max_dist : @core.Real,
   solid : Bool,
@@ -3987,10 +4003,10 @@ pub fn QueryPipeline::project_point_and_get_feature(
   // Rapier keeps this parameter for API consistency, but doesn't use it.
   max_dist |> ignore
   let mut best : (ColliderHandle, PointProjection, FeatureId, @core.Real)? = None
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
-      let handle = ColliderHandle::new(i, self.colliders.generations[i])
-      if !self.filter.passes(self.bodies, handle, collider) {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+      let handle = ColliderHandle::new(i, colliders.generations[i])
+      if !self.filter.passes(bodies, handle, collider) {
         continue
       }
       let (projection, feature) = project_point_on_shape_and_get_feature(
@@ -4021,13 +4037,15 @@ pub fn QueryPipeline::project_point_and_get_feature(
 ///|
 pub fn QueryPipeline::intersect_point(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   point : @core.Vec2,
 ) -> Array[ColliderHandle] {
   let result : Array[ColliderHandle] = []
-  for i in 0..<self.colliders.colliders.length() {
-    if self.colliders.colliders[i] is Some(collider) && collider.is_enabled() {
-      let handle = ColliderHandle::new(i, self.colliders.generations[i])
-      if !self.filter.passes(self.bodies, handle, collider) {
+  for i in 0..<colliders.colliders.length() {
+    if colliders.colliders[i] is Some(collider) && collider.is_enabled() {
+      let handle = ColliderHandle::new(i, colliders.generations[i])
+      if !self.filter.passes(bodies, handle, collider) {
         continue
       }
       if point_in_shape(

--- a/collision/query_pipeline3d_real.mbt
+++ b/collision/query_pipeline3d_real.mbt
@@ -374,8 +374,6 @@ fn filter_pass_3d_real(
 ///|
 pub struct QueryPipeline3DReal {
   filter : QueryFilter3DReal
-  bodies : @dynamics.RigidBodySet3D
-  colliders : ColliderSet3D
   // Cached world-space AABBs to accelerate repeated queries (e.g. character controller).
   mut cached_aabbs : Array[@core.Aabb3?]
 }
@@ -391,15 +389,20 @@ pub fn QueryPipeline3DReal::new(
   bodies : @dynamics.RigidBodySet3D,
   colliders : ColliderSet3D,
 ) -> QueryPipeline3DReal {
-  let qp = { filter, bodies, colliders, cached_aabbs: [] }
-  qp.update()
+  let qp = { filter, cached_aabbs: [] }
+  qp.update(bodies, colliders)
   qp
 }
 
 ///|
-pub fn QueryPipeline3DReal::update(self : QueryPipeline3DReal) -> Unit {
+pub fn QueryPipeline3DReal::update(
+  self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
+) -> Unit {
+  colliders.sync_with_bodies(bodies)
   // Cache AABBs for all colliders (including fixed ones) to speed up repeated queries.
-  let n = self.colliders.colliders.length()
+  let n = colliders.colliders.length()
   if self.cached_aabbs.length() != n {
     self.cached_aabbs = []
     for _ in 0..<n {
@@ -411,7 +414,7 @@ pub fn QueryPipeline3DReal::update(self : QueryPipeline3DReal) -> Unit {
     }
   }
   for i in 0..<n {
-    if self.colliders.colliders[i] is Some(co) {
+    if colliders.colliders[i] is Some(co) {
       self.cached_aabbs[i] = Some(co.compute_aabb())
     }
   }
@@ -422,12 +425,7 @@ pub fn QueryPipeline3DReal::with_filter(
   self : QueryPipeline3DReal,
   filter : QueryFilter3DReal,
 ) -> QueryPipeline3DReal {
-  {
-    filter,
-    bodies: self.bodies,
-    colliders: self.colliders,
-    cached_aabbs: self.cached_aabbs,
-  }
+  { filter, cached_aabbs: self.cached_aabbs }
 }
 
 ///|
@@ -447,32 +445,42 @@ pub fn QueryPipelineMut3DReal::as_ref(
 }
 
 ///|
-pub fn QueryPipelineMut3DReal::update(self : QueryPipelineMut3DReal) -> Unit {
-  self.pipeline.update()
+pub fn QueryPipelineMut3DReal::update(
+  self : QueryPipelineMut3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
+) -> Unit {
+  self.pipeline.update(bodies, colliders)
 }
 
 ///|
 pub fn QueryPipeline3DReal::rigid_body(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
   handle : @dynamics.RigidBodyHandle,
 ) -> @dynamics.RigidBody3D? {
-  self.bodies.get(handle)
+  self |> ignore
+  bodies.get(handle)
 }
 
 ///|
 pub fn QueryPipeline3DReal::rigid_body_mut(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
   handle : @dynamics.RigidBodyHandle,
 ) -> @dynamics.RigidBody3D? {
-  self.bodies.get_mut(handle)
+  self |> ignore
+  bodies.get_mut(handle)
 }
 
 ///|
 pub fn QueryPipeline3DReal::collider(
   self : QueryPipeline3DReal,
+  colliders : ColliderSet3D,
   handle : ColliderHandle3D,
 ) -> Collider3D? {
-  self.colliders.get(handle)
+  self |> ignore
+  colliders.get(handle)
 }
 
 ///|
@@ -1594,12 +1602,14 @@ fn ray_cone_y_toi_normal(
 ///|
 pub fn QueryPipeline3DReal::cast_ray_and_get_normal(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   ray : Ray3,
   max_toi : @core.Real,
   solid : Bool,
 ) -> (ColliderHandle3D, RayIntersection3)? {
   if QueryPipeline3DReal::cast_ray_and_get_normal_and_feature(
-      self, ray, max_toi, solid,
+      self, bodies, colliders, ray, max_toi, solid,
     )
     is Some((h, it)) {
     Some((h, { toi: it.toi, normal: it.normal }))
@@ -1611,12 +1621,14 @@ pub fn QueryPipeline3DReal::cast_ray_and_get_normal(
 ///|
 pub fn QueryPipeline3DReal::cast_ray(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   ray : Ray3,
   max_toi : @core.Real,
   solid : Bool,
 ) -> (ColliderHandle3D, @core.Real)? {
   if QueryPipeline3DReal::cast_ray_and_get_normal_and_feature(
-      self, ray, max_toi, solid,
+      self, bodies, colliders, ray, max_toi, solid,
     )
     is Some((h, it)) {
     Some((h, it.toi))
@@ -1628,6 +1640,8 @@ pub fn QueryPipeline3DReal::cast_ray(
 ///|
 pub fn QueryPipeline3DReal::intersect_ray(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   ray : Ray3,
   max_toi : @core.Real,
   solid : Bool,
@@ -1635,9 +1649,9 @@ pub fn QueryPipeline3DReal::intersect_ray(
   solid |> ignore
   let max_dist = if max_toi < 0.0F { 0.0F } else { max_toi }
   let results : Array[(ColliderHandle3D, RayIntersection3Feature)] = []
-  for h in self.colliders.all_handles() {
-    if self.colliders.get(h) is Some(co) {
-      if !filter_pass_3d_real(self.filter, self.bodies, h, co) {
+  for h in colliders.all_handles() {
+    if colliders.get(h) is Some(co) {
+      if !filter_pass_3d_real(self.filter, bodies, h, co) {
         continue
       }
       if qp3d_real_hit_shape(ray, co.position(), co.shape(), max_dist)
@@ -1652,18 +1666,20 @@ pub fn QueryPipeline3DReal::intersect_ray(
 ///|
 pub fn QueryPipeline3DReal::cast_ray_and_get_normal_and_feature(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   ray : Ray3,
   max_toi : @core.Real,
   solid : Bool,
 ) -> (ColliderHandle3D, RayIntersection3Feature)? {
   solid |> ignore
-  let handles = self.colliders.all_handles()
+  let handles = colliders.all_handles()
   let mut best_t = max_toi + 1.0F
   let mut best : (ColliderHandle3D, RayIntersection3Feature)? = None
   for i in 0..<handles.length() {
     let h = handles[i]
-    if self.colliders.get(h) is Some(co) {
-      if !filter_pass_3d_real(self.filter, self.bodies, h, co) {
+    if colliders.get(h) is Some(co) {
+      if !filter_pass_3d_real(self.filter, bodies, h, co) {
         continue
       }
       let pos = co.position()
@@ -1680,15 +1696,17 @@ pub fn QueryPipeline3DReal::cast_ray_and_get_normal_and_feature(
 ///|
 pub fn QueryPipeline3DReal::cast_ray_and_get_voxel_key(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   ray : Ray3,
   max_toi : @core.Real,
   solid : Bool,
 ) -> (ColliderHandle3D, RayIntersection3, (Int, Int, Int))? {
   if QueryPipeline3DReal::cast_ray_and_get_normal_and_feature(
-      self, ray, max_toi, solid,
+      self, bodies, colliders, ray, max_toi, solid,
     )
     is Some((h, it)) {
-    if it.feature_id >= 0 && self.colliders.get(h) is Some(co) {
+    if it.feature_id >= 0 && colliders.get(h) is Some(co) {
       if co.voxel_key_for_triangle(it.feature_id) is Some(key) {
         return Some((h, { toi: it.toi, normal: it.normal }, key))
       }
@@ -1702,12 +1720,14 @@ pub fn QueryPipeline3DReal::cast_ray_and_get_voxel_key(
 ///|
 pub fn QueryPipeline3DReal::intersect_aabb_conservative(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   aabb : @core.Aabb3,
 ) -> Array[ColliderHandle3D] {
   let out : Array[ColliderHandle3D] = []
-  for h in self.colliders.all_handles() {
-    if self.colliders.get(h) is Some(co) {
-      if !filter_pass_3d_real(self.filter, self.bodies, h, co) {
+  for h in colliders.all_handles() {
+    if colliders.get(h) is Some(co) {
+      if !filter_pass_3d_real(self.filter, bodies, h, co) {
         continue
       }
       // Conservative query: uses current collider AABB.
@@ -2295,6 +2315,8 @@ fn qp3d_real_project_point_on_shape(
 ///|
 pub fn QueryPipeline3DReal::project_point(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   point : @core.Vec3,
   max_dist : @core.Real,
   solid : Bool,
@@ -2303,9 +2325,9 @@ pub fn QueryPipeline3DReal::project_point(
   let max_d2 = max_d * max_d
   let mut best : (ColliderHandle3D, PointProjection3)? = None
   let mut best_d2 = max_d2 + 1.0F
-  for h in self.colliders.all_handles() {
-    if self.colliders.get(h) is Some(co) {
-      if !filter_pass_3d_real(self.filter, self.bodies, h, co) {
+  for h in colliders.all_handles() {
+    if colliders.get(h) is Some(co) {
+      if !filter_pass_3d_real(self.filter, bodies, h, co) {
         continue
       }
       let (proj, d2) = qp3d_real_project_point_on_shape(
@@ -2372,12 +2394,14 @@ fn qp3d_real_contains_point(
 ///|
 pub fn QueryPipeline3DReal::intersect_point(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   point : @core.Vec3,
 ) -> Array[ColliderHandle3D] {
   let out : Array[ColliderHandle3D] = []
-  for h in self.colliders.all_handles() {
-    if self.colliders.get(h) is Some(co) {
-      if !filter_pass_3d_real(self.filter, self.bodies, h, co) {
+  for h in colliders.all_handles() {
+    if colliders.get(h) is Some(co) {
+      if !filter_pass_3d_real(self.filter, bodies, h, co) {
         continue
       }
       if qp3d_real_contains_point(co.position(), co.shape(), point) {
@@ -3663,6 +3687,8 @@ fn qp3d_real_cast_moving_shape(
 ///|
 pub fn QueryPipeline3DReal::cast_shape(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   shape_pos : @core.Isometry3,
   shape_vel : @core.Vec3,
   shape : Shape3D,
@@ -3704,11 +3730,11 @@ pub fn QueryPipeline3DReal::cast_shape(
   let sweep_aabb = start_aabb.combine(end_aabb).dilated(td)
   let mut best : (ColliderHandle3D, ShapeCastHit3)? = None
   let mut best_t = max_toi + 1.0F
-  let n = self.colliders.colliders.length()
+  let n = colliders.colliders.length()
   for i in 0..<n {
-    if self.colliders.colliders[i] is Some(co) {
-      let h = ColliderHandle3D::from_raw_parts(i, self.colliders.generations[i])
-      if !filter_pass_3d_real(self.filter, self.bodies, h, co) {
+    if colliders.colliders[i] is Some(co) {
+      let h = ColliderHandle3D::from_raw_parts(i, colliders.generations[i])
+      if !filter_pass_3d_real(self.filter, bodies, h, co) {
         continue
       }
       if self.cached_aabbs[i] is Some(aabb) && !sweep_aabb.intersects(aabb) {

--- a/collision/query_pipeline3d_real_test.mbt
+++ b/collision/query_pipeline3d_real_test.mbt
@@ -30,7 +30,8 @@ test "query_pipeline3d_real: cast_ray_and_get_normal cuboid" {
     @core.Vec3::new(0.0F, 5.0F, 0.0F),
     @core.Vec3::new(0.0F, -1.0F, 0.0F),
   )
-  if qp.cast_ray_and_get_normal(ray, 10.0F, true) is Some((_h, hit)) {
+  if qp.cast_ray_and_get_normal(bodies, colliders, ray, 10.0F, true)
+    is Some((_h, hit)) {
     inspect(hit.toi() > 3.0F, content="true")
     inspect(hit.normal().y > 0.9F, content="true")
   } else {
@@ -58,7 +59,8 @@ test "query_pipeline3d_real: cast_ray_and_get_normal trimesh triangle" {
     @core.Vec3::new(0.0F, 2.0F, 0.0F),
     @core.Vec3::new(0.0F, -1.0F, 0.0F),
   )
-  if qp.cast_ray_and_get_normal(ray, 10.0F, true) is Some((_h, hit)) {
+  if qp.cast_ray_and_get_normal(bodies, colliders, ray, 10.0F, true)
+    is Some((_h, hit)) {
     inspect(hit.toi() > 1.0F, content="true")
     let n = hit.normal()
     inspect(n.x == n.x && n.y == n.y && n.z == n.z, content="true")
@@ -87,7 +89,8 @@ test "query_pipeline3d_real: cast_shape capsule vs cuboid" {
   let shape_vel = @core.Vec3::new(1.0F, 0.0F, 0.0F)
   let shape = Shape3D::capsule_y(0.5F, 1.0F)
   let options = ShapeCastOptions3::new(10.0F, true)
-  if qp.cast_shape(shape_pos, shape_vel, shape, options) is Some((_h, hit)) {
+  if qp.cast_shape(bodies, colliders, shape_pos, shape_vel, shape, options)
+    is Some((_h, hit)) {
     inspect(hit.toi() > 3.0F, content="true")
     inspect(hit.toi() < 4.0F, content="true")
     inspect(hit.normal().x < -0.9F, content="true")
@@ -127,7 +130,8 @@ test "query_pipeline3d_real: cast_ray_and_get_voxel_key voxels" {
     @core.Vec3::new(0.5F, 10.0F, 0.5F),
     @core.Vec3::new(0.0F, -1.0F, 0.0F),
   )
-  if qp.cast_ray_and_get_voxel_key(ray, 20.0F, true) is Some((_h, hit, key)) {
+  if qp.cast_ray_and_get_voxel_key(bodies, colliders, ray, 20.0F, true)
+    is Some((_h, hit, key)) {
     inspect(hit.toi() > 8.5F && hit.toi() < 9.5F, content="true")
     inspect(hit.normal().y > 0.9F, content="true")
     inspect(key.0 == 0 && key.1 == 0 && key.2 == 0, content="true")
@@ -192,7 +196,8 @@ test "query_pipeline3d_real: cast_ray_and_get_voxel_key voxels (wavy floor)" {
     @core.Vec3::new(center_x, origin_y, center_z),
     @core.Vec3::new(0.0F, -1.0F, 0.0F),
   )
-  if qp.cast_ray_and_get_voxel_key(ray0, 200.0F, true) is Some((_h, _hit, _key)) {
+  if qp.cast_ray_and_get_voxel_key(bodies, colliders, ray0, 200.0F, true)
+    is Some((_h, _hit, _key)) {
     inspect(true, content="true")
   } else {
     inspect(false, content="true")
@@ -201,7 +206,8 @@ test "query_pipeline3d_real: cast_ray_and_get_voxel_key voxels (wavy floor)" {
     @core.Vec3::new(center_x + 0.5F, origin_y, center_z + 0.5F),
     @core.Vec3::new(0.0F, -1.0F, 0.0F),
   )
-  if qp.cast_ray_and_get_voxel_key(ray1, 200.0F, true) is Some((_h, _hit, _key)) {
+  if qp.cast_ray_and_get_voxel_key(bodies, colliders, ray1, 200.0F, true)
+    is Some((_h, _hit, _key)) {
     inspect(true, content="true")
   } else {
     inspect(false, content="true")
@@ -255,7 +261,8 @@ test "query_pipeline3d_real: exclude_collider + groups filter affects ray hits" 
     bodies,
     colliders,
   )
-  if qp0.cast_ray_and_get_normal(ray, 20.0F, true) is Some((h0, hit0)) {
+  if qp0.cast_ray_and_get_normal(bodies, colliders, ray, 20.0F, true)
+    is Some((h0, hit0)) {
     inspect(h0.equals(upper), content="true")
     inspect(hit0.toi() > 2.0F && hit0.toi() < 3.0F, content="true")
   } else {
@@ -268,7 +275,8 @@ test "query_pipeline3d_real: exclude_collider + groups filter affects ray hits" 
     bodies,
     colliders,
   )
-  if qp1.cast_ray_and_get_normal(ray, 20.0F, true) is Some((h1, hit1)) {
+  if qp1.cast_ray_and_get_normal(bodies, colliders, ray, 20.0F, true)
+    is Some((h1, hit1)) {
     inspect(h1.equals(lower), content="true")
     inspect(hit1.toi() > 4.0F && hit1.toi() < 5.0F, content="true")
   } else {
@@ -283,7 +291,8 @@ test "query_pipeline3d_real: exclude_collider + groups filter affects ray hits" 
     bodies,
     colliders,
   )
-  if qp2.cast_ray_and_get_normal(ray, 20.0F, true) is Some((h2, _hit2)) {
+  if qp2.cast_ray_and_get_normal(bodies, colliders, ray, 20.0F, true)
+    is Some((h2, _hit2)) {
     inspect(h2.equals(lower), content="true")
   } else {
     inspect(false, content="true")

--- a/collision/query_pipeline_test.mbt
+++ b/collision/query_pipeline_test.mbt
@@ -37,7 +37,7 @@ test "query pipeline cast_ray hits nearest collider" {
     QueryFilter::new(),
   )
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if query_pipeline.cast_ray(ray, 100.0F, true) is Some(hit) {
+  if query_pipeline.cast_ray(bodies, colliders, ray, 100.0F, true) is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, ch1), content="true")
     inspect(!ColliderHandle::equals(hit.0, ch2), content="true")
     inspect(@core.abs(hit.1 - 9.5F) < 1.0e-4F, content="true")
@@ -70,7 +70,7 @@ test "query pipeline intersect_ray returns all hits" {
     QueryFilter::new(),
   )
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  let hits = query_pipeline.intersect_ray(ray, 100.0F, true)
+  let hits = query_pipeline.intersect_ray(bodies, colliders, ray, 100.0F, true)
   let mut found1 = false
   let mut found2 = false
   for i in 0..<hits.length() {
@@ -104,13 +104,15 @@ test "query pipeline cast_ray solid vs hollow" {
     QueryFilter::new(),
   )
   let ray = Ray::new(@core.Vec2::new(0.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if query_pipeline.cast_ray(ray, 10.0F, true) is Some(hit_solid) {
+  if query_pipeline.cast_ray(bodies, colliders, ray, 10.0F, true)
+    is Some(hit_solid) {
     inspect(ColliderHandle::equals(hit_solid.0, ch1), content="true")
     inspect(@core.abs(hit_solid.1) < 1.0e-6F, content="true")
   } else {
     inspect(false, content="true")
   }
-  if query_pipeline.cast_ray(ray, 10.0F, false) is Some(hit_hollow) {
+  if query_pipeline.cast_ray(bodies, colliders, ray, 10.0F, false)
+    is Some(hit_hollow) {
     inspect(ColliderHandle::equals(hit_hollow.0, ch1), content="true")
     inspect(@core.abs(hit_hollow.1 - 1.0F) < 1.0e-4F, content="true")
   } else {
@@ -131,7 +133,10 @@ test "query pipeline cast_ray_and_get_normal returns toi and outward normal" {
     QueryFilter::new(),
   )
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if query_pipeline.cast_ray_and_get_normal(ray, 100.0F, true) is Some(hit) {
+  if query_pipeline.cast_ray_and_get_normal(
+      bodies, colliders, ray, 100.0F, true,
+    )
+    is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, handle), content="true")
     inspect(@core.abs(hit.1.toi() - 9.0F) < 1.0e-4F, content="true")
     let n = hit.1.normal()
@@ -159,7 +164,9 @@ test "query pipeline cast_ray_and_get_normal inside solid vs hollow" {
     QueryFilter::new(),
   )
   let ray = Ray::new(@core.Vec2::new(0.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if query_pipeline.cast_ray_and_get_normal(ray, 100.0F, true)
+  if query_pipeline.cast_ray_and_get_normal(
+      bodies, colliders, ray, 100.0F, true,
+    )
     is Some(hit_solid) {
     inspect(@core.abs(hit_solid.1.toi()) < 1.0e-6F, content="true")
     let n = hit_solid.1.normal()
@@ -169,7 +176,9 @@ test "query pipeline cast_ray_and_get_normal inside solid vs hollow" {
   } else {
     inspect(false, content="true")
   }
-  if query_pipeline.cast_ray_and_get_normal(ray, 100.0F, false)
+  if query_pipeline.cast_ray_and_get_normal(
+      bodies, colliders, ray, 100.0F, false,
+    )
     is Some(hit_hollow) {
     inspect(@core.abs(hit_hollow.1.toi() - 1.0F) < 1.0e-4F, content="true")
     let n = hit_hollow.1.normal()
@@ -200,7 +209,14 @@ test "query pipeline cast_shape ball hits ball" {
   )
   let vel = @core.Vec2::new(1.0F, 0.0F)
   let options = ShapeCastOptions::new(100.0F, true)
-  if query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(1.0F), options)
+  if query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(1.0F),
+      options,
+    )
     is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, handle), content="true")
     inspect(@core.abs(hit.1.toi() - 8.0F) < 1.0e-4F, content="true")
@@ -241,7 +257,14 @@ test "query pipeline cast_shape ball hits rotated cuboid" {
   let options = ShapeCastOptions::new(100.0F, true)
   // Ball radius 0.5 against a 90deg-rotated cuboid with world x half-extent 0.5:
   // expanded boundary is at x = -(0.5 + 0.5) = -1.0, so toi = 9.0.
-  if query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(0.5F), options)
+  if query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(0.5F),
+      options,
+    )
     is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, handle), content="true")
     inspect(@core.abs(hit.1.toi() - 9.0F) < 1.0e-4F, content="true")
@@ -285,7 +308,7 @@ test "query pipeline filter exclude rigid body" {
   let broad_phase = BroadPhaseBvh::new()
   let query_pipeline = broad_phase.as_query_pipeline(bodies, colliders, filter)
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if query_pipeline.cast_ray(ray, 100.0F, true) is Some(hit) {
+  if query_pipeline.cast_ray(bodies, colliders, ray, 100.0F, true) is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, ch2), content="true")
   } else {
     inspect(false, content="true")
@@ -313,7 +336,10 @@ test "query pipeline filter collision groups" {
   let broad_phase = BroadPhaseBvh::new()
   let query_pipeline = broad_phase.as_query_pipeline(bodies, colliders, filter)
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  inspect(query_pipeline.cast_ray(ray, 100.0F, true) is None, content="true")
+  inspect(
+    query_pipeline.cast_ray(bodies, colliders, ray, 100.0F, true) is None,
+    content="true",
+  )
 }
 
 ///|
@@ -346,7 +372,7 @@ test "query filter predicate can exclude colliders" {
     bodies, colliders, filter,
   )
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if query_pipeline.cast_ray(ray, 100.0F, true) is Some(hit) {
+  if query_pipeline.cast_ray(bodies, colliders, ray, 100.0F, true) is Some(hit) {
     inspect(!ColliderHandle::equals(hit.0, near), content="true")
     inspect(ColliderHandle::equals(hit.0, far), content="true")
   } else {
@@ -367,7 +393,10 @@ test "query pipeline cast_ray hits capsule" {
     QueryFilter::new(),
   )
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if query_pipeline.cast_ray_and_get_normal(ray, 100.0F, true) is Some(hit) {
+  if query_pipeline.cast_ray_and_get_normal(
+      bodies, colliders, ray, 100.0F, true,
+    )
+    is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, handle), content="true")
     inspect(@core.abs(hit.1.toi() - 9.5F) < 1.0e-4F, content="true")
     let n = hit.1.normal()
@@ -399,6 +428,8 @@ test "query pipeline cast_shape capsule hits ball" {
   let vel = @core.Vec2::new(1.0F, 0.0F)
   let options = ShapeCastOptions::new(100.0F, true)
   if query_pipeline.cast_shape(
+      bodies,
+      colliders,
       shape_pos,
       vel,
       Shape::CapsuleY(1.0F, 0.5F),
@@ -434,7 +465,8 @@ test "query pipeline cast_ray hits segment" {
     QueryFilter::new(),
   )
   let ray = Ray::new(@core.Vec2::new(0.0F, -1.0F), @core.Vec2::new(0.0F, 1.0F))
-  if query_pipeline.cast_ray_and_get_normal(ray, 10.0F, true) is Some(hit) {
+  if query_pipeline.cast_ray_and_get_normal(bodies, colliders, ray, 10.0F, true)
+    is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, handle), content="true")
     inspect(@core.abs(hit.1.toi() - 1.0F) < 1.0e-4F, content="true")
     let n = hit.1.normal()
@@ -469,7 +501,14 @@ test "query pipeline cast_shape ball hits segment (core)" {
   )
   let vel = @core.Vec2::new(0.0F, 1.0F)
   let options = ShapeCastOptions::new(100.0F, true)
-  if query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(0.5F), options)
+  if query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(0.5F),
+      options,
+    )
     is Some(hit) {
     inspect(@core.abs(hit.1.toi() - 9.5F) < 1.0e-4F, content="true")
     let n = hit.1.normal()
@@ -505,7 +544,14 @@ test "query pipeline cast_shape ball hits segment endpoint (rounded caps)" {
   let shape_pos = @core.Isometry2::from_translation(@core.Vec2::new(2.0F, 0.5F))
   let vel = @core.Vec2::new(-1.0F, 0.0F)
   let options = ShapeCastOptions::new(10.0F, true)
-  if query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(1.0F), options)
+  if query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(1.0F),
+      options,
+    )
     is Some(hit) {
     // The earliest contact is against the endpoint at (1, 0):
     // distance((2 - t, 0.5), (1, 0)) = 1 => t = 1 - sqrt(0.75) = ~0.1339746.
@@ -546,6 +592,8 @@ test "query pipeline cast_shape cuboid hits segment with target_distance" {
   let vel = @core.Vec2::new(0.0F, 1.0F)
   let options = ShapeCastOptions::new(100.0F, true).with_target_distance(0.2F)
   if query_pipeline.cast_shape(
+      bodies,
+      colliders,
       shape_pos,
       vel,
       Shape::Cuboid(1.0F, 1.0F),
@@ -588,6 +636,8 @@ test "query pipeline cast_shape capsule_y hits segment with target_distance" {
   let vel = @core.Vec2::new(0.0F, 1.0F)
   let options = ShapeCastOptions::new(100.0F, true).with_target_distance(0.2F)
   if query_pipeline.cast_shape(
+      bodies,
+      colliders,
       shape_pos,
       vel,
       Shape::CapsuleY(1.0F, 0.5F),
@@ -626,7 +676,14 @@ test "query pipeline cast_shape target_distance applies to non-segment shapes (b
   )
   let vel = @core.Vec2::new(0.0F, 1.0F)
   let options = ShapeCastOptions::new(100.0F, true).with_target_distance(0.5F)
-  if query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(1.0F), options)
+  if query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(1.0F),
+      options,
+    )
     is Some(hit) {
     // Distance between centers is 10. "Impact" when dist <= (r1 + target_distance) + r2.
     // => toi = 10 - (1.0 + 0.5) - 1.0 = 7.5.
@@ -660,14 +717,28 @@ test "query pipeline cast_shape stop_at_penetration=false discards separating pe
   let vel = @core.Vec2::new(0.0F, 1.0F)
   let options = ShapeCastOptions::new(10.0F, false)
   inspect(
-    query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(1.0F), options)
+    query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(1.0F),
+      options,
+    )
     is None,
     content="true",
   )
   // With stop_at_penetration=true, we keep the toi=0 hit.
   let options2 = ShapeCastOptions::new(10.0F, true)
   inspect(
-    query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(1.0F), options2)
+    query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(1.0F),
+      options2,
+    )
     is Some(_),
     content="true",
   )
@@ -694,13 +765,27 @@ test "query pipeline cast_shape stop_at_penetration=false discards separating pe
   let vel = @core.Vec2::new(1.0F, 0.0F)
   let options = ShapeCastOptions::new(10.0F, false)
   inspect(
-    query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(0.5F), options)
+    query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(0.5F),
+      options,
+    )
     is None,
     content="true",
   )
   let options2 = ShapeCastOptions::new(10.0F, true)
   inspect(
-    query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(0.5F), options2)
+    query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(0.5F),
+      options2,
+    )
     is Some(_),
     content="true",
   )
@@ -730,13 +815,27 @@ test "query pipeline cast_shape stop_at_penetration=false discards separating pe
   let vel = @core.Vec2::new(0.0F, 1.0F)
   let options = ShapeCastOptions::new(10.0F, false)
   inspect(
-    query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(0.5F), options)
+    query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(0.5F),
+      options,
+    )
     is None,
     content="true",
   )
   let options2 = ShapeCastOptions::new(10.0F, true)
   inspect(
-    query_pipeline.cast_shape(shape_pos, vel, Shape::Ball(0.5F), options2)
+    query_pipeline.cast_shape(
+      bodies,
+      colliders,
+      shape_pos,
+      vel,
+      Shape::Ball(0.5F),
+      options2,
+    )
     is Some(_),
     content="true",
   )
@@ -769,7 +868,11 @@ test "query pipeline intersect_point" {
     colliders,
     QueryFilter::new(),
   )
-  let results = query_pipeline.intersect_point(@core.Vec2::new(1.0F, 0.0F))
+  let results = query_pipeline.intersect_point(
+    bodies,
+    colliders,
+    @core.Vec2::new(1.0F, 0.0F),
+  )
   inspect(results.length() == 1, content="true")
   inspect(ColliderHandle::equals(results[0], ch1), content="true")
 }
@@ -791,7 +894,13 @@ test "query pipeline project_point ignores max_dist and matches solid semantics"
   )
 
   // Outside point; max_dist is ignored.
-  if query_pipeline.project_point(@core.Vec2::new(2.0F, 0.0F), 0.01F, true)
+  if query_pipeline.project_point(
+      bodies,
+      colliders,
+      @core.Vec2::new(2.0F, 0.0F),
+      0.01F,
+      true,
+    )
     is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, handle), content="true")
     inspect(@core.abs(hit.1.point().x - 1.0F) < 1.0e-4F, content="true")
@@ -802,7 +911,13 @@ test "query pipeline project_point ignores max_dist and matches solid semantics"
   }
 
   // Inside point with solid=true projects to itself.
-  if query_pipeline.project_point(@core.Vec2::new(0.2F, 0.0F), 0.01F, true)
+  if query_pipeline.project_point(
+      bodies,
+      colliders,
+      @core.Vec2::new(0.2F, 0.0F),
+      0.01F,
+      true,
+    )
     is Some(hit) {
     inspect(@core.abs(hit.1.point().x - 0.2F) < 1.0e-4F, content="true")
     inspect(hit.1.is_inside() == true, content="true")
@@ -811,7 +926,13 @@ test "query pipeline project_point ignores max_dist and matches solid semantics"
   }
 
   // Inside point with solid=false projects to the boundary.
-  if query_pipeline.project_point(@core.Vec2::new(0.2F, 0.0F), 0.01F, false)
+  if query_pipeline.project_point(
+      bodies,
+      colliders,
+      @core.Vec2::new(0.2F, 0.0F),
+      0.01F,
+      false,
+    )
     is Some(hit) {
     inspect(@core.abs(hit.1.point().x - 1.0F) < 1.0e-4F, content="true")
     inspect(hit.1.is_inside() == true, content="true")
@@ -838,6 +959,8 @@ test "query pipeline project_point_and_get_feature cuboid face vs vertex" {
 
   // Near the +X face.
   if query_pipeline.project_point_and_get_feature(
+      bodies,
+      colliders,
       @core.Vec2::new(3.0F, 0.25F),
       0.0F,
       false,
@@ -856,6 +979,8 @@ test "query pipeline project_point_and_get_feature cuboid face vs vertex" {
 
   // Near the (+,+) corner.
   if query_pipeline.project_point_and_get_feature(
+      bodies,
+      colliders,
       @core.Vec2::new(3.0F, 3.0F),
       0.0F,
       false,
@@ -892,6 +1017,8 @@ test "query pipeline project_point_and_get_feature segment endpoint" {
     QueryFilter::new(),
   )
   if query_pipeline.project_point_and_get_feature(
+      bodies,
+      colliders,
       @core.Vec2::new(1.0F, 0.0F),
       0.0F,
       false,
@@ -938,7 +1065,7 @@ test "query pipeline with_filter overrides the pipeline filter" {
     QueryFilter::new().exclude_sensors(),
   )
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if filtered.cast_ray(ray, 100.0F, true) is Some(hit) {
+  if filtered.cast_ray(bodies, colliders, ray, 100.0F, true) is Some(hit) {
     inspect(!ColliderHandle::equals(hit.0, sensor), content="true")
     inspect(ColliderHandle::equals(hit.0, solid), content="true")
   } else {
@@ -964,7 +1091,7 @@ test "query pipeline cast_ray respects cuboid rotation" {
     QueryFilter::new(),
   )
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if query_pipeline.cast_ray(ray, 100.0F, true) is Some(hit) {
+  if query_pipeline.cast_ray(bodies, colliders, ray, 100.0F, true) is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, handle), content="true")
     // Rotated cuboid has world half-extent 0.5 along x, so it hits at x = -0.5.
     inspect(@core.abs(hit.1 - 9.5F) < 1.0e-4F, content="true")
@@ -1004,7 +1131,7 @@ test "query pipeline intersect_aabb_conservative uses cached aabbs" {
     @core.Vec2::new(-2.0F, -2.0F),
     @core.Vec2::new(2.0F, 2.0F),
   )
-  let results = pipeline.intersect_aabb_conservative(query)
+  let results = pipeline.intersect_aabb_conservative(bodies, colliders, query)
   inspect(results.length() == 1, content="true")
   inspect(ColliderHandle::equals(results[0], h1), content="true")
 
@@ -1013,8 +1140,10 @@ test "query pipeline intersect_aabb_conservative uses cached aabbs" {
   if bodies.get_mut(body1) is Some(b) {
     b.set_translation(@core.Vec2::new(100.0F, 0.0F), true) |> ignore
   }
-  broad_phase.update(0.0F, bodies, pipeline.colliders)
-  let results_after = pipeline.intersect_aabb_conservative(query)
+  broad_phase.update(0.0F, bodies, colliders)
+  let results_after = pipeline.intersect_aabb_conservative(
+    bodies, colliders, query,
+  )
   inspect(results_after.length() == 1, content="true")
   inspect(ColliderHandle::equals(results_after[0], h1), content="true")
 }
@@ -1041,7 +1170,11 @@ test "query pipeline intersect_point respects cuboid rotation" {
     QueryFilter::new(),
   )
   // This point is inside the AABB of the cuboid but outside the rotated cuboid itself.
-  let results = query_pipeline.intersect_point(@core.Vec2::new(1.2F, 0.0F))
+  let results = query_pipeline.intersect_point(
+    bodies,
+    colliders,
+    @core.Vec2::new(1.2F, 0.0F),
+  )
   inspect(results.length() == 0, content="true")
 }
 
@@ -1068,7 +1201,7 @@ test "query filter exclude sensors vs solids" {
       colliders,
       QueryFilter::new().exclude_sensors(),
     )
-    if pipeline.cast_ray(ray, 100.0F, true) is Some(hit) {
+    if pipeline.cast_ray(bodies, colliders, ray, 100.0F, true) is Some(hit) {
       inspect(ColliderHandle::equals(hit.0, solid_handle), content="true")
     } else {
       inspect(false, content="true")
@@ -1093,7 +1226,7 @@ test "query filter exclude sensors vs solids" {
     colliders,
     QueryFilter::new().exclude_solids(),
   )
-  if pipeline.cast_ray(ray, 100.0F, true) is Some(hit) {
+  if pipeline.cast_ray(bodies, colliders, ray, 100.0F, true) is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, sensor_handle), content="true")
   } else {
     inspect(false, content="true")
@@ -1127,7 +1260,7 @@ test "query filter only_dynamic ignores fixed colliders" {
     QueryFilter::only_dynamic(),
   )
   let ray = Ray::new(@core.Vec2::new(-10.0F, 0.0F), @core.Vec2::new(1.0F, 0.0F))
-  if query_pipeline.cast_ray(ray, 100.0F, true) is Some(hit) {
+  if query_pipeline.cast_ray(bodies, colliders, ray, 100.0F, true) is Some(hit) {
     inspect(ColliderHandle::equals(hit.0, dynamic_collider), content="true")
   } else {
     inspect(false, content="true")
@@ -1150,7 +1283,12 @@ test "query pipeline intersect_shape ball intersects cuboid" {
     QueryFilter::new(),
   )
   let shape_pos = @core.Isometry2::from_translation(@core.Vec2::new(1.4F, 0.0F))
-  let hits = query_pipeline.intersect_shape(shape_pos, Shape::Ball(0.5F))
+  let hits = query_pipeline.intersect_shape(
+    bodies,
+    colliders,
+    shape_pos,
+    Shape::Ball(0.5F),
+  )
   if hits.length() == 1 {
     inspect(ColliderHandle::equals(hits[0], handle), content="true")
   } else {
@@ -1178,6 +1316,8 @@ test "query pipeline intersect_shape uses query rotation" {
     @core.Rot2::from_angle(@core.pi() * 0.5F),
   )
   let hits = query_pipeline.intersect_shape(
+    bodies,
+    colliders,
     shape_pos,
     Shape::Cuboid(0.2F, 1.0F),
   )
@@ -1211,7 +1351,12 @@ test "query pipeline intersect_shape respects exclude_sensors filter" {
     QueryFilter::new().exclude_sensors(),
   )
   let shape_pos = @core.Isometry2::from_translation(@core.Vec2::new(0.0F, 0.0F))
-  let hits = query_pipeline.intersect_shape(shape_pos, Shape::Ball(0.5F))
+  let hits = query_pipeline.intersect_shape(
+    bodies,
+    colliders,
+    shape_pos,
+    Shape::Ball(0.5F),
+  )
   if hits.length() == 1 {
     inspect(ColliderHandle::equals(hits[0], solid), content="true")
   } else {
@@ -1244,6 +1389,8 @@ test "query pipeline cast_shape_nonlinear detects rotation-only hit" {
     @core.pi() * 0.5F,
   )
   if query_pipeline.cast_shape_nonlinear(
+      bodies,
+      colliders,
       motion,
       Shape::Cuboid(2.0F, 0.2F),
       0.0F,
@@ -1282,9 +1429,12 @@ test "query pipeline update refreshes collider world state + aabb cache" {
   }
 
   // Without `update`, the collider still has the old world position, so the ray misses.
-  inspect(q.cast_ray(ray, 100.0F, true) is None, content="true")
-  q.update()
-  if q.cast_ray(ray, 100.0F, true) is Some((hit, _)) {
+  inspect(
+    q.cast_ray(bodies, colliders, ray, 100.0F, true) is None,
+    content="true",
+  )
+  q.update(bodies, colliders)
+  if q.cast_ray(bodies, colliders, ray, 100.0F, true) is Some((hit, _)) {
     inspect(ColliderHandle::equals(hit, ch), content="true")
   } else {
     inspect(false, content="true")
@@ -1315,9 +1465,10 @@ test "query pipeline mut wrapper provides as_ref and update" {
   } else {
     inspect(false, content="true")
   }
-  qm.update()
+  qm.update(bodies, colliders)
   let ray = Ray::new(@core.Vec2::new(5.0F, 10.0F), @core.Vec2::new(0.0F, -1.0F))
-  if qm.as_ref().cast_ray(ray, 100.0F, true) is Some((hit, _)) {
+  if qm.as_ref().cast_ray(bodies, colliders, ray, 100.0F, true)
+    is Some((hit, _)) {
     inspect(ColliderHandle::equals(hit, ch), content="true")
   } else {
     inspect(false, content="true")

--- a/collision/spec.mbt
+++ b/collision/spec.mbt
@@ -2064,7 +2064,11 @@ pub fn QueryPipeline::new3(
 
 ///|
 #declaration_only
-pub fn QueryPipeline::update(self : QueryPipeline) -> Unit {
+pub fn QueryPipeline::update(
+  self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
+) -> Unit {
   ...
 }
 
@@ -2110,7 +2114,11 @@ pub fn QueryPipelineMut::as_ref(self : QueryPipelineMut) -> QueryPipeline {
 
 ///|
 #declaration_only
-pub fn QueryPipelineMut::update(self : QueryPipelineMut) -> Unit {
+pub fn QueryPipelineMut::update(
+  self : QueryPipelineMut,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
+) -> Unit {
   ...
 }
 
@@ -2118,6 +2126,8 @@ pub fn QueryPipelineMut::update(self : QueryPipelineMut) -> Unit {
 #declaration_only
 pub fn QueryPipeline::cast_ray(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   ray : Ray,
   max_toi : @core.Real,
   solid : Bool,
@@ -2129,6 +2139,8 @@ pub fn QueryPipeline::cast_ray(
 #declaration_only
 pub fn QueryPipeline::cast_ray_and_get_normal(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   ray : Ray,
   max_toi : @core.Real,
   solid : Bool,
@@ -2156,7 +2168,11 @@ pub fn QueryPipeline3DReal::new(
 
 ///|
 #declaration_only
-pub fn QueryPipeline3DReal::update(self : QueryPipeline3DReal) -> Unit {
+pub fn QueryPipeline3DReal::update(
+  self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
+) -> Unit {
   ...
 }
 
@@ -2173,6 +2189,8 @@ pub fn QueryPipeline3DReal::with_filter(
 #declaration_only
 pub fn QueryPipeline3DReal::cast_ray_and_get_normal(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
   ray : Ray3,
   max_toi : @core.Real,
   solid : Bool,
@@ -2184,6 +2202,7 @@ pub fn QueryPipeline3DReal::cast_ray_and_get_normal(
 #declaration_only
 pub fn QueryPipeline3DReal::rigid_body(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
   handle : @dynamics.RigidBodyHandle,
 ) -> @dynamics.RigidBody3D? {
   ...
@@ -2193,6 +2212,7 @@ pub fn QueryPipeline3DReal::rigid_body(
 #declaration_only
 pub fn QueryPipeline3DReal::rigid_body_mut(
   self : QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
   handle : @dynamics.RigidBodyHandle,
 ) -> @dynamics.RigidBody3D? {
   ...
@@ -2202,6 +2222,7 @@ pub fn QueryPipeline3DReal::rigid_body_mut(
 #declaration_only
 pub fn QueryPipeline3DReal::collider(
   self : QueryPipeline3DReal,
+  colliders : ColliderSet3D,
   handle : ColliderHandle3D,
 ) -> Collider3D? {
   ...
@@ -2227,7 +2248,11 @@ pub fn QueryPipelineMut3DReal::as_ref(
 
 ///|
 #declaration_only
-pub fn QueryPipelineMut3DReal::update(self : QueryPipelineMut3DReal) -> Unit {
+pub fn QueryPipelineMut3DReal::update(
+  self : QueryPipelineMut3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
+) -> Unit {
   ...
 }
 
@@ -2235,6 +2260,8 @@ pub fn QueryPipelineMut3DReal::update(self : QueryPipelineMut3DReal) -> Unit {
 #declaration_only
 pub fn QueryPipeline::intersect_ray(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   ray : Ray,
   max_toi : @core.Real,
   solid : Bool,
@@ -2246,6 +2273,8 @@ pub fn QueryPipeline::intersect_ray(
 #declaration_only
 pub fn QueryPipeline::cast_shape(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   shape_pos : @core.Isometry2,
   shape_vel : @core.Vec2,
   shape : Shape,
@@ -2258,6 +2287,8 @@ pub fn QueryPipeline::cast_shape(
 #declaration_only
 pub fn QueryPipeline::cast_shape_nonlinear(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   shape_motion : NonlinearRigidMotion,
   shape : Shape,
   start_time : @core.Real,
@@ -2271,6 +2302,7 @@ pub fn QueryPipeline::cast_shape_nonlinear(
 #declaration_only
 pub fn QueryPipeline::collider(
   self : QueryPipeline,
+  colliders : ColliderSet,
   handle : ColliderHandle,
 ) -> Collider? {
   ...
@@ -2280,6 +2312,7 @@ pub fn QueryPipeline::collider(
 #declaration_only
 pub fn QueryPipeline::rigid_body(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
   handle : @dynamics.RigidBodyHandle,
 ) -> @dynamics.RigidBody? {
   ...
@@ -2289,6 +2322,8 @@ pub fn QueryPipeline::rigid_body(
 #declaration_only
 pub fn QueryPipeline::intersect_shape(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   shape_pos : @core.Isometry2,
   shape : Shape,
 ) -> Array[ColliderHandle] {
@@ -2299,6 +2334,8 @@ pub fn QueryPipeline::intersect_shape(
 #declaration_only
 pub fn QueryPipeline::project_point(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   point : @core.Vec2,
   max_dist : @core.Real,
   solid : Bool,
@@ -2310,6 +2347,8 @@ pub fn QueryPipeline::project_point(
 #declaration_only
 pub fn QueryPipeline::project_point_and_get_feature(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   point : @core.Vec2,
   max_dist : @core.Real,
   solid : Bool,
@@ -2321,6 +2360,8 @@ pub fn QueryPipeline::project_point_and_get_feature(
 #declaration_only
 pub fn QueryPipeline::intersect_aabb_conservative(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   aabb : @core.Aabb,
 ) -> Array[ColliderHandle] {
   ...
@@ -2330,6 +2371,8 @@ pub fn QueryPipeline::intersect_aabb_conservative(
 #declaration_only
 pub fn QueryPipeline::intersect_point(
   self : QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
   point : @core.Vec2,
 ) -> Array[ColliderHandle] {
   ...

--- a/control/character_controller.mbt
+++ b/control/character_controller.mbt
@@ -619,6 +619,8 @@ fn handle_slopes(
 ///|
 fn detect_ground_contact(
   query : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   shape : @collision.Shape,
   position : @core.Isometry2,
   up : @core.Vec2,
@@ -630,7 +632,8 @@ fn detect_ground_contact(
   let options = @collision.ShapeCastOptions::new(prediction, true).with_target_distance(
     offset,
   )
-  if query.cast_shape(position, down, shape, options) is Some(hit) {
+  if query.cast_shape(bodies, colliders, position, down, shape, options)
+    is Some(hit) {
     let normal = hit.1.normal()
     // For the controller to be grounded, the angle between the contact normal and the up vector
     // has to be smaller than acos(1.0e-3) ≈ 89.94 degrees.
@@ -647,6 +650,8 @@ fn detect_ground_contact(
 ///|
 fn attempt_autostep(
   query : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   shape : @collision.Shape,
   start_pos : @core.Isometry2,
   remaining : @core.Vec2,
@@ -668,9 +673,9 @@ fn attempt_autostep(
   }
   if !autostep.include_dynamic_bodies() {
     // If the obstacle is dynamic, ignore it (Rapier parity).
-    if query.collider(stair_handle) is Some(co) &&
+    if query.collider(colliders, stair_handle) is Some(co) &&
       co.parent() is Some(parent) &&
-      query.rigid_body(parent) is Some(body) &&
+      query.rigid_body(bodies, parent) is Some(body) &&
       body.is_dynamic() {
       return None
     }
@@ -689,6 +694,8 @@ fn attempt_autostep(
 
   // Can we go up?
   if query.cast_shape(
+      bodies,
+      colliders,
       start_pos,
       up,
       shape,
@@ -702,6 +709,8 @@ fn attempt_autostep(
 
   // Is there enough room on the stair after stepping?
   if query.cast_shape(
+      bodies,
+      colliders,
       shifted_pos,
       horizontal_dir,
       shape,
@@ -719,6 +728,8 @@ fn attempt_autostep(
     shifted_pos.rotation,
   )
   if query.cast_shape(
+      bodies,
+      colliders,
       pos_on_stair,
       down,
       shape,
@@ -742,6 +753,8 @@ fn attempt_autostep(
 
   // Find actual step height.
   let toi_down = if query.cast_shape(
+      bodies,
+      colliders,
       pos_on_stair,
       down,
       shape,
@@ -767,31 +780,39 @@ fn attempt_autostep(
 ///|
 fn detect_grounded(
   query : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   shape : @collision.Shape,
   position : @core.Isometry2,
   up : @core.Vec2,
   prediction : @core.Real,
   offset : @core.Real,
 ) -> Bool {
-  detect_ground_contact(query, shape, position, up, prediction, offset)
+  detect_ground_contact(
+    query, bodies, colliders, shape, position, up, prediction, offset,
+  )
   is Some(_)
 }
 
 ///|
 fn grounded_info(
   query : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   shape : @collision.Shape,
   position : @core.Isometry2,
   up : @core.Vec2,
   prediction : @core.Real,
   offset : @core.Real,
 ) -> (Bool, @core.Vec2) {
-  if detect_ground_contact(query, shape, position, up, prediction, offset)
+  if detect_ground_contact(
+      query, bodies, colliders, shape, position, up, prediction, offset,
+    )
     is Some(hit) {
     let handle = hit.0
-    if query.collider(handle) is Some(co) &&
+    if query.collider(colliders, handle) is Some(co) &&
       co.parent is Some(parent) &&
-      query.rigid_body(parent) is Some(body) &&
+      query.rigid_body(bodies, parent) is Some(body) &&
       body.is_kinematic() {
       (true, body.linvel())
     } else {
@@ -807,6 +828,8 @@ pub fn KinematicCharacterController::move_shape(
   self : KinematicCharacterController,
   dt : @core.Real,
   query : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   shape : @collision.Shape,
   position : @core.Isometry2,
   translation : @core.Vec2,
@@ -823,6 +846,8 @@ pub fn KinematicCharacterController::move_shape(
   // Rapier parity: `check_and_fix_penetrations` is currently a stub upstream.
   let grounded_at_start = grounded_info(
       query,
+      bodies,
+      colliders,
       shape,
       @core.Isometry2::new(
         position.translation.add(result_translation),
@@ -849,7 +874,8 @@ pub fn KinematicCharacterController::move_shape(
     let options = @collision.ShapeCastOptions::new(dist, false).with_target_distance(
       offset,
     )
-    if query.cast_shape(current_pos, dir, shape, options) is Some(hit) {
+    if query.cast_shape(bodies, colliders, current_pos, dir, shape, options)
+      is Some(hit) {
       let toi = hit.1.toi()
       let allowed_dist = toi
       let applied = vec2_scale(dir, allowed_dist)
@@ -870,6 +896,8 @@ pub fn KinematicCharacterController::move_shape(
       if self.autostep is Some(autostep) && hit_info.is_wall {
         if attempt_autostep(
             query,
+            bodies,
+            colliders,
             shape,
             event_pos,
             remaining,
@@ -897,6 +925,8 @@ pub fn KinematicCharacterController::move_shape(
     grounded = grounded ||
       detect_grounded(
         query,
+        bodies,
+        colliders,
         shape,
         @core.Isometry2::new(
           position.translation.add(result_translation),
@@ -911,7 +941,9 @@ pub fn KinematicCharacterController::move_shape(
     }
   }
   if iters == 0 {
-    grounded = grounded_info(query, shape, position, up, prediction, offset).0
+    grounded = grounded_info(
+        query, bodies, colliders, shape, position, up, prediction, offset,
+      ).0
   }
   if grounded_at_start && !grounded && self.snap_to_ground is Some(snap_length) {
     let snap_dist = character_length_eval(snap_length, up_extent)
@@ -924,7 +956,8 @@ pub fn KinematicCharacterController::move_shape(
       let options = @collision.ShapeCastOptions::new(snap_dist, false).with_target_distance(
         offset,
       )
-      if query.cast_shape(current_pos, down, shape, options) is Some(hit) {
+      if query.cast_shape(bodies, colliders, current_pos, down, shape, options)
+        is Some(hit) {
         result_translation = result_translation.add(
           vec2_scale(down, hit.1.toi()),
         )
@@ -936,7 +969,9 @@ pub fn KinematicCharacterController::move_shape(
     position.translation.add(result_translation),
     position.rotation,
   )
-  let end_info = grounded_info(query, shape, final_pos, up, prediction, offset)
+  let end_info = grounded_info(
+    query, bodies, colliders, shape, final_pos, up, prediction, offset,
+  )
   if end_info.0 {
     grounded = true
     result_translation = result_translation.add(
@@ -955,6 +990,8 @@ pub fn KinematicCharacterController::solve_character_collision_impulses(
   self : KinematicCharacterController,
   dt : @core.Real,
   query : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   character_shape : @collision.Shape,
   character_mass : @core.Real,
   collisions : Array[CharacterCollision],
@@ -985,9 +1022,9 @@ pub fn KinematicCharacterController::solve_character_collision_impulses(
     let vel_to_transfer = vec2_scale(to_transfer, 1.0F / dt)
     let point = hit.point()
     let handle = collision.handle()
-    if query.collider(handle) is Some(co) &&
+    if query.collider(colliders, handle) is Some(co) &&
       co.parent() is Some(parent) &&
-      query.bodies.get_mut(parent) is Some(body) {
+      bodies.get_mut(parent) is Some(body) {
       if !body.is_dynamic() || !body.is_enabled() {
         continue
       }

--- a/control/character_controller3d_real.mbt
+++ b/control/character_controller3d_real.mbt
@@ -453,6 +453,8 @@ fn cc3d_real_handle_slopes(
 ///|
 fn cc3d_real_detect_ground_contact(
   query : @collision.QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
   shape : @collision.Shape3D,
   position : @core.Isometry3,
   up : @core.Vec3,
@@ -463,7 +465,8 @@ fn cc3d_real_detect_ground_contact(
   let options = @collision.ShapeCastOptions3::new(prediction, true).with_target_distance(
     offset,
   )
-  if query.cast_shape(position, down, shape, options) is Some(hit) {
+  if query.cast_shape(bodies, colliders, position, down, shape, options)
+    is Some(hit) {
     let normal = hit.1.normal()
     // For the controller to be grounded, the angle between the contact normal and the up vector
     // has to be smaller than acos(1.0e-3) ≈ 89.94 degrees.
@@ -480,6 +483,8 @@ fn cc3d_real_detect_ground_contact(
 ///|
 fn cc3d_real_detect_grounded(
   query : @collision.QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
   shape : @collision.Shape3D,
   position : @core.Isometry3,
   up : @core.Vec3,
@@ -487,7 +492,7 @@ fn cc3d_real_detect_grounded(
   offset : @core.Real,
 ) -> Bool {
   cc3d_real_detect_ground_contact(
-    query, shape, position, up, prediction, offset,
+    query, bodies, colliders, shape, position, up, prediction, offset,
   )
   is Some(_)
 }
@@ -495,6 +500,8 @@ fn cc3d_real_detect_grounded(
 ///|
 fn cc3d_real_grounded_info(
   query : @collision.QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
   shape : @collision.Shape3D,
   position : @core.Isometry3,
   up : @core.Vec3,
@@ -502,13 +509,13 @@ fn cc3d_real_grounded_info(
   offset : @core.Real,
 ) -> (Bool, @core.Vec3) {
   if cc3d_real_detect_ground_contact(
-      query, shape, position, up, prediction, offset,
+      query, bodies, colliders, shape, position, up, prediction, offset,
     )
     is Some(hit) {
     let handle = hit.0
-    if query.collider(handle) is Some(co) &&
+    if query.collider(colliders, handle) is Some(co) &&
       co.parent is Some(parent) &&
-      query.rigid_body(parent) is Some(body) &&
+      query.rigid_body(bodies, parent) is Some(body) &&
       body.body_type().is_kinematic() {
       (true, body.linvel())
     } else {
@@ -522,6 +529,8 @@ fn cc3d_real_grounded_info(
 ///|
 fn cc3d_real_attempt_autostep(
   query : @collision.QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
   shape : @collision.Shape3D,
   start_pos : @core.Isometry3,
   remaining : @core.Vec3,
@@ -549,9 +558,9 @@ fn cc3d_real_attempt_autostep(
   }
   if !autostep.include_dynamic_bodies() {
     // If the obstacle is dynamic, ignore it (Rapier parity).
-    if query.collider(stair_handle) is Some(co) &&
+    if query.collider(colliders, stair_handle) is Some(co) &&
       co.parent() is Some(parent) &&
-      query.rigid_body(parent) is Some(body) &&
+      query.rigid_body(bodies, parent) is Some(body) &&
       body.body_type().is_dynamic() {
       return None
     }
@@ -570,6 +579,8 @@ fn cc3d_real_attempt_autostep(
 
   // Can we go up?
   if query.cast_shape(
+      bodies,
+      colliders,
       start_pos,
       up,
       shape,
@@ -583,6 +594,8 @@ fn cc3d_real_attempt_autostep(
 
   // Is there enough room on the stair after stepping?
   if query.cast_shape(
+      bodies,
+      colliders,
       shifted_pos,
       horizontal_dir,
       shape,
@@ -600,6 +613,8 @@ fn cc3d_real_attempt_autostep(
     shifted_pos.rotation,
   )
   if query.cast_shape(
+      bodies,
+      colliders,
       pos_on_stair,
       down,
       shape,
@@ -623,6 +638,8 @@ fn cc3d_real_attempt_autostep(
 
   // Find actual step height.
   let toi_down = if query.cast_shape(
+      bodies,
+      colliders,
       pos_on_stair,
       down,
       shape,
@@ -650,6 +667,8 @@ pub fn KinematicCharacterController3DReal::move_shape(
   self : KinematicCharacterController3DReal,
   dt : @core.Real,
   query : @collision.QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
   shape : @collision.Shape3D,
   position : @core.Isometry3,
   translation : @core.Vec3,
@@ -672,6 +691,8 @@ pub fn KinematicCharacterController3DReal::move_shape(
   // Rapier parity: `check_and_fix_penetrations` is currently a stub upstream.
   let grounded_at_start = cc3d_real_grounded_info(
       query,
+      bodies,
+      colliders,
       shape,
       @core.Isometry3::new(
         position.translation.add(result_translation),
@@ -698,7 +719,8 @@ pub fn KinematicCharacterController3DReal::move_shape(
     let options = @collision.ShapeCastOptions3::new(dist, false).with_target_distance(
       offset,
     )
-    if query.cast_shape(current_pos, dir, shape, options) is Some(hit) {
+    if query.cast_shape(bodies, colliders, current_pos, dir, shape, options)
+      is Some(hit) {
       let toi = hit.1.toi()
       let allowed_dist = toi
       let applied = dir.scale(allowed_dist)
@@ -719,6 +741,8 @@ pub fn KinematicCharacterController3DReal::move_shape(
       if controller.autostep is Some(autostep) && hit_info.is_wall {
         if cc3d_real_attempt_autostep(
             query,
+            bodies,
+            colliders,
             shape,
             event_pos,
             remaining,
@@ -746,6 +770,8 @@ pub fn KinematicCharacterController3DReal::move_shape(
     grounded = grounded ||
       cc3d_real_detect_grounded(
         query,
+        bodies,
+        colliders,
         shape,
         @core.Isometry3::new(
           position.translation.add(result_translation),
@@ -761,7 +787,7 @@ pub fn KinematicCharacterController3DReal::move_shape(
   }
   if iters == 0 {
     grounded = cc3d_real_grounded_info(
-        query, shape, position, up, prediction, offset,
+        query, bodies, colliders, shape, position, up, prediction, offset,
       ).0
   }
   if grounded_at_start &&
@@ -777,7 +803,8 @@ pub fn KinematicCharacterController3DReal::move_shape(
       let options = @collision.ShapeCastOptions3::new(snap_dist, false).with_target_distance(
         offset,
       )
-      if query.cast_shape(current_pos, down, shape, options) is Some(hit) {
+      if query.cast_shape(bodies, colliders, current_pos, down, shape, options)
+        is Some(hit) {
         result_translation = result_translation.add(down.scale(hit.1.toi()))
         grounded = true
       }
@@ -788,7 +815,7 @@ pub fn KinematicCharacterController3DReal::move_shape(
     position.rotation,
   )
   let end_info = cc3d_real_grounded_info(
-    query, shape, final_pos, up, prediction, offset,
+    query, bodies, colliders, shape, final_pos, up, prediction, offset,
   )
   if end_info.0 {
     grounded = true
@@ -806,6 +833,8 @@ pub fn KinematicCharacterController3DReal::solve_character_collision_impulses(
   self : KinematicCharacterController3DReal,
   dt : @core.Real,
   query : @collision.QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
   character_shape : @collision.Shape3D,
   character_mass : @core.Real,
   collisions : Array[CharacterCollision3DReal],
@@ -832,9 +861,9 @@ pub fn KinematicCharacterController3DReal::solve_character_collision_impulses(
     let vel_to_transfer = to_transfer.scale(1.0F / dt)
     let point = hit.point()
     let handle = collision.handle()
-    if query.collider(handle) is Some(co) &&
+    if query.collider(colliders, handle) is Some(co) &&
       co.parent() is Some(parent) &&
-      query.rigid_body_mut(parent) is Some(body) {
+      query.rigid_body_mut(bodies, parent) is Some(body) {
       if !body.body_type().is_dynamic() {
         continue
       }

--- a/control/character_controller_test.mbt
+++ b/control/character_controller_test.mbt
@@ -101,6 +101,8 @@ test "character controller climb" {
         let effective_movement = controller.move_shape(
           integration_parameters.dt,
           query_pipeline,
+          bodies,
+          colliders,
           character_shape,
           character_body.position(),
           @core.Vec2::new(0.1F, -0.1F),
@@ -270,6 +272,8 @@ test "character controller moving platform keeps grounded and follows platform" 
       let movement = controller.move_shape(
         dt,
         query_pipeline,
+        bodies,
+        colliders,
         character_shape,
         character_body.position(),
         @core.Vec2::new(0.0F, -0.1F),
@@ -389,6 +393,8 @@ test "character controller autostep climbs stairs" {
       let movement = controller.move_shape(
         dt,
         query_pipeline,
+        bodies,
+        colliders,
         character_shape,
         character_body.position(),
         @core.Vec2::new(0.08F, -0.1F),
@@ -488,6 +494,8 @@ test "character controller reports sliding on steep slope but not on flat ground
     let m = controller_flat.move_shape(
       dt,
       query_pipeline,
+      bodies,
+      colliders,
       character_shape,
       character_body.position(),
       @core.Vec2::new(0.05F, 0.0F),
@@ -526,6 +534,8 @@ test "character controller reports sliding on steep slope but not on flat ground
       let m = controller_steep.move_shape(
         dt,
         query_pipeline,
+        bodies,
+        colliders,
         character_shape,
         character_body.position(),
         @core.Vec2::new(0.1F, -0.1F),
@@ -564,6 +574,8 @@ test "character controller slides along wall" {
   let movement = controller.move_shape(
     0.016F,
     query_pipeline,
+    bodies,
+    colliders,
     shape,
     start_pos,
     desired,
@@ -598,6 +610,8 @@ test "character controller collision event includes hit info" {
   let movement = controller.move_shape(
     0.016F,
     query_pipeline,
+    bodies,
+    colliders,
     shape,
     start_pos,
     @core.Vec2::new(2.0F, 0.0F),
@@ -642,6 +656,8 @@ test "character controller follows kinematic platform velocity" {
   let movement = controller.move_shape(
     1.0F,
     query_pipeline,
+    bodies,
+    colliders,
     shape,
     start_pos,
     @core.Vec2::zero(),
@@ -682,6 +698,8 @@ test "character controller autostep moves past obstacle" {
   let no_step = controller_no_step.move_shape(
     0.016F,
     query_pipeline,
+    bodies,
+    colliders,
     shape,
     start_pos,
     desired,
@@ -699,6 +717,8 @@ test "character controller autostep moves past obstacle" {
   let stepped = controller_step.move_shape(
     0.016F,
     query_pipeline,
+    bodies,
+    colliders,
     shape,
     start_pos,
     desired,
@@ -780,6 +800,8 @@ test "character controller ground detection" {
         let effective_movement = controller.move_shape(
           integration_parameters.dt,
           query_pipeline,
+          bodies,
+          colliders,
           character_shape,
           character_body.position(),
           @core.Vec2::new(0.1F, -0.1F),
@@ -833,6 +855,8 @@ test "character controller grounded on rotated cuboid (cuboid character)" {
   let movement = controller.move_shape(
     0.016F,
     query_pipeline,
+    bodies,
+    colliders,
     shape,
     start_pos,
     @core.Vec2::new(0.0F, -4.0F),
@@ -864,6 +888,8 @@ test "character controller grounded on rotated cuboid (capsule character)" {
   let movement = controller.move_shape(
     0.016F,
     query_pipeline,
+    bodies,
+    colliders,
     shape,
     start_pos,
     @core.Vec2::new(0.0F, -4.0F),
@@ -896,6 +922,8 @@ test "character controller grounded on segment" {
   let movement = controller.move_shape(
     0.016F,
     query_pipeline,
+    bodies,
+    colliders,
     shape,
     start_pos,
     @core.Vec2::new(0.0F, -4.0F),
@@ -974,6 +1002,8 @@ test "character controller transfers impulse to dynamic body" {
   let movement = controller.move_shape(
     dt,
     query_pipeline,
+    bodies,
+    colliders,
     character_shape,
     start_pos,
     @core.Vec2::new(4.0F, 0.0F),
@@ -983,7 +1013,7 @@ test "character controller transfers impulse to dynamic body" {
   inspect(movement.translation().x > 0.0F, content="true")
   inspect(collisions.length() > 0, content="true")
   controller.solve_character_collision_impulses(
-    dt, query_pipeline, character_shape, 1.0F, collisions,
+    dt, query_pipeline, bodies, colliders, character_shape, 1.0F, collisions,
   )
   if bodies.get(box_handle) is Some(body) {
     inspect(body.linvel().x > 0.0F, content="true")

--- a/control/pkg.generated.mbti
+++ b/control/pkg.generated.mbti
@@ -69,7 +69,7 @@ pub fn DynamicRayCastVehicleController::add_wheel(Self, @core.Vec2, @core.Vec2, 
 pub fn DynamicRayCastVehicleController::new(@dynamics.RigidBodyHandle) -> Self
 pub fn DynamicRayCastVehicleController::set_brake(Self, Int, Float) -> Unit
 pub fn DynamicRayCastVehicleController::set_engine_force(Self, Int, Float) -> Unit
-pub fn DynamicRayCastVehicleController::update_vehicle(Self, Float, @collision.QueryPipelineMut) -> Unit
+pub fn DynamicRayCastVehicleController::update_vehicle(Self, Float, @collision.QueryPipelineMut, @dynamics.RigidBodySet, @collision.ColliderSet) -> Unit
 
 pub struct DynamicRayCastVehicleController3 {
   wheels : Array[Wheel3]
@@ -85,7 +85,7 @@ pub fn DynamicRayCastVehicleController3::new(@dynamics.RigidBodyHandle) -> Self
 pub fn DynamicRayCastVehicleController3::set_brake(Self, Int, Float) -> Unit
 pub fn DynamicRayCastVehicleController3::set_engine_force(Self, Int, Float) -> Unit
 pub fn DynamicRayCastVehicleController3::set_steering_value(Self, Int, Float) -> Unit
-pub fn DynamicRayCastVehicleController3::update_vehicle(Self, Float, @collision.QueryPipelineMut) -> Unit
+pub fn DynamicRayCastVehicleController3::update_vehicle(Self, Float, @collision.QueryPipelineMut, @dynamics.RigidBodySet, @collision.ColliderSet) -> Unit
 pub fn DynamicRayCastVehicleController3::wheels(Self) -> Array[Wheel3]
 
 pub struct DynamicRayCastVehicleController3DReal {
@@ -102,7 +102,7 @@ pub fn DynamicRayCastVehicleController3DReal::new(@dynamics.RigidBodyHandle) -> 
 pub fn DynamicRayCastVehicleController3DReal::set_brake(Self, Int, Float) -> Unit
 pub fn DynamicRayCastVehicleController3DReal::set_engine_force(Self, Int, Float) -> Unit
 pub fn DynamicRayCastVehicleController3DReal::set_steering_value(Self, Int, Float) -> Unit
-pub fn DynamicRayCastVehicleController3DReal::update_vehicle(Self, Float, @collision.QueryPipelineMut3DReal) -> Unit
+pub fn DynamicRayCastVehicleController3DReal::update_vehicle(Self, Float, @collision.QueryPipelineMut3DReal, @dynamics.RigidBodySet3D, @collision.ColliderSet3D) -> Unit
 pub fn DynamicRayCastVehicleController3DReal::wheels(Self) -> Array[Wheel3DReal]
 
 pub struct EffectiveMovement {
@@ -134,9 +134,9 @@ pub struct KinematicCharacterController {
   normal_nudge_factor : Float
 }
 pub fn KinematicCharacterController::default() -> Self
-pub fn KinematicCharacterController::move_shape(Self, Float, @collision.QueryPipeline, @collision.Shape, @core.Isometry2, @core.Vec2, (CharacterCollision) -> Unit) -> EffectiveMovement
+pub fn KinematicCharacterController::move_shape(Self, Float, @collision.QueryPipeline, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.Shape, @core.Isometry2, @core.Vec2, (CharacterCollision) -> Unit) -> EffectiveMovement
 pub fn KinematicCharacterController::new() -> Self
-pub fn KinematicCharacterController::solve_character_collision_impulses(Self, Float, @collision.QueryPipeline, @collision.Shape, Float, Array[CharacterCollision]) -> Unit
+pub fn KinematicCharacterController::solve_character_collision_impulses(Self, Float, @collision.QueryPipeline, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.Shape, Float, Array[CharacterCollision]) -> Unit
 pub fn KinematicCharacterController::with_autostep(Self, CharacterAutostep?) -> Self
 pub fn KinematicCharacterController::with_max_slope_climb_angle(Self, Float) -> Self
 pub fn KinematicCharacterController::with_min_slope_slide_angle(Self, Float) -> Self
@@ -157,9 +157,9 @@ pub struct KinematicCharacterController3DReal {
   normal_nudge_factor : Float
 }
 pub fn KinematicCharacterController3DReal::default() -> Self
-pub fn KinematicCharacterController3DReal::move_shape(Self, Float, @collision.QueryPipeline3DReal, @collision.Shape3D, @core.Isometry3, @core.Vec3, (CharacterCollision3DReal) -> Unit) -> EffectiveMovement3DReal
+pub fn KinematicCharacterController3DReal::move_shape(Self, Float, @collision.QueryPipeline3DReal, @dynamics.RigidBodySet3D, @collision.ColliderSet3D, @collision.Shape3D, @core.Isometry3, @core.Vec3, (CharacterCollision3DReal) -> Unit) -> EffectiveMovement3DReal
 pub fn KinematicCharacterController3DReal::new() -> Self
-pub fn KinematicCharacterController3DReal::solve_character_collision_impulses(Self, Float, @collision.QueryPipeline3DReal, @collision.Shape3D, Float, Array[CharacterCollision3DReal]) -> Unit
+pub fn KinematicCharacterController3DReal::solve_character_collision_impulses(Self, Float, @collision.QueryPipeline3DReal, @dynamics.RigidBodySet3D, @collision.ColliderSet3D, @collision.Shape3D, Float, Array[CharacterCollision3DReal]) -> Unit
 pub fn KinematicCharacterController3DReal::with_autostep(Self, CharacterAutostep?) -> Self
 pub fn KinematicCharacterController3DReal::with_max_slope_climb_angle(Self, Float) -> Self
 pub fn KinematicCharacterController3DReal::with_min_slope_slide_angle(Self, Float) -> Self

--- a/control/ray_cast_vehicle_controller.mbt
+++ b/control/ray_cast_vehicle_controller.mbt
@@ -409,6 +409,8 @@ fn update_wheel_transforms_ws(
 ///|
 fn ray_cast(
   queries : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   chassis : @dynamics.RigidBody,
   wheel : Wheel,
 ) -> Wheel {
@@ -420,7 +422,8 @@ fn ray_cast(
   out.raycast_info.contact_point_ws = source.add(
     veh_vec2_scale(ray_dir, raylen),
   )
-  if queries.cast_ray_and_get_normal(ray, raylen, true) is Some(hit) {
+  if queries.cast_ray_and_get_normal(bodies, colliders, ray, raylen, true)
+    is Some(hit) {
     let collider_hit = hit.0
     let intersection = hit.1
     out.raycast_info.contact_normal_ws = intersection.normal()
@@ -571,10 +574,12 @@ pub fn DynamicRayCastVehicleController::update_vehicle(
   self : DynamicRayCastVehicleController,
   dt : @core.Real,
   queries : @collision.QueryPipelineMut,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
 ) -> Unit {
-  queries.update()
+  queries.update(bodies, colliders)
   let qp = queries.as_ref()
-  let chassis = match qp.rigid_body(self.chassis) {
+  let chassis = match qp.rigid_body(bodies, self.chassis) {
     Some(rb) => rb
     None => return
   }
@@ -583,7 +588,7 @@ pub fn DynamicRayCastVehicleController::update_vehicle(
   for i in 0..<self.wheels.length() {
     let mut w = self.wheels[i]
     w = update_wheel_transforms_ws(chassis, w)
-    w = ray_cast(qp, chassis, w)
+    w = ray_cast(qp, bodies, colliders, chassis, w)
     self.wheels[i] = w
   }
   let chassis_mass = chassis.mass()
@@ -595,7 +600,7 @@ pub fn DynamicRayCastVehicleController::update_vehicle(
 
   // Apply suspension impulses.
   // Need a mutable body for impulses.
-  if qp.bodies.get_mut_internal_with_modification_tracking(self.chassis)
+  if bodies.get_mut_internal_with_modification_tracking(self.chassis)
     is Some(rb) {
     for i in 0..<self.wheels.length() {
       let w = self.wheels[i]
@@ -626,7 +631,7 @@ pub fn DynamicRayCastVehicleController::update_vehicle(
   if wheels_on_ground == 0 {
     return
   }
-  if qp.bodies.get_mut_internal_with_modification_tracking(self.chassis)
+  if bodies.get_mut_internal_with_modification_tracking(self.chassis)
     is Some(rb) {
     let fwd_axis_ws = rb
       .rotation()
@@ -658,9 +663,9 @@ pub fn DynamicRayCastVehicleController::update_vehicle(
         let max_impulse = if w.brake != 0.0F { w.brake } else { 0.0F }
         let mut ground_body : @dynamics.RigidBody? = None
         if w.raycast_info.ground_object is Some(h) {
-          if qp.collider(h) is Some(c) {
+          if qp.collider(colliders, h) is Some(c) {
             if c.parent() is Some(parent) {
-              ground_body = qp.rigid_body(parent)
+              ground_body = qp.rigid_body(bodies, parent)
             }
           }
         }
@@ -691,7 +696,7 @@ pub fn DynamicRayCastVehicleController::update_vehicle(
   }
 
   // Wheel rotation update.
-  if qp.rigid_body(self.chassis) is Some(rb2) {
+  if qp.rigid_body(bodies, self.chassis) is Some(rb2) {
     let fwd_axis_ws = rb2
       .rotation()
       .rotate_vec2(axis_vec2(self.index_forward_axis))

--- a/control/ray_cast_vehicle_controller3.mbt
+++ b/control/ray_cast_vehicle_controller3.mbt
@@ -324,6 +324,8 @@ fn update_wheel_transforms_ws3(
 ///|
 fn ray_cast3(
   queries : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   chassis : @dynamics.RigidBody,
   wheel : Wheel3,
 ) -> Wheel3 {
@@ -335,7 +337,8 @@ fn ray_cast3(
   let ray_dir = v3_to_v2(ray_dir_ws)
   let ray = @collision.Ray::new(source, ray_dir)
   out.raycast_info.contact_point_ws = source_ws.add(ray_dir_ws.scale(raylen))
-  if queries.cast_ray_and_get_normal(ray, raylen, true) is Some(hit) {
+  if queries.cast_ray_and_get_normal(bodies, colliders, ray, raylen, true)
+    is Some(hit) {
     let collider_hit = hit.0
     let intersection = hit.1
     let normal2 = intersection.normal()
@@ -635,10 +638,12 @@ pub fn DynamicRayCastVehicleController3::update_vehicle(
   self : DynamicRayCastVehicleController3,
   dt : @core.Real,
   queries : @collision.QueryPipelineMut,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
 ) -> Unit {
-  queries.update()
+  queries.update(bodies, colliders)
   let qp = queries.as_ref()
-  let chassis = match qp.rigid_body(self.chassis) {
+  let chassis = match qp.rigid_body(bodies, self.chassis) {
     Some(rb) => rb
     None => return
   }
@@ -662,7 +667,7 @@ pub fn DynamicRayCastVehicleController3::update_vehicle(
   // Suspension ray casts.
   for i in 0..<num_wheels {
     let w = self.wheels[i]
-    self.wheels[i] = ray_cast3(qp, chassis, w)
+    self.wheels[i] = ray_cast3(qp, bodies, colliders, chassis, w)
   }
   let chassis_mass = chassis.mass()
   for i in 0..<num_wheels {
@@ -671,7 +676,7 @@ pub fn DynamicRayCastVehicleController3::update_vehicle(
   }
 
   // Apply suspension impulses.
-  if qp.bodies.get_mut_internal_with_modification_tracking(self.chassis)
+  if bodies.get_mut_internal_with_modification_tracking(self.chassis)
     is Some(rb) {
     for i in 0..<num_wheels {
       let w = self.wheels[i]
@@ -693,10 +698,10 @@ pub fn DynamicRayCastVehicleController3::update_vehicle(
       |> ignore
     }
   }
-  update_friction3(self, qp.bodies, qp.colliders, dt)
+  update_friction3(self, bodies, colliders, dt)
 
   // Update wheel rotation.
-  if qp.bodies.get_mut_internal_with_modification_tracking(self.chassis)
+  if bodies.get_mut_internal_with_modification_tracking(self.chassis)
     is Some(rb) {
     let fwd_axis = rotate_vec3_yaw(
       rb.rotation(),

--- a/control/ray_cast_vehicle_controller3d_real.mbt
+++ b/control/ray_cast_vehicle_controller3d_real.mbt
@@ -419,6 +419,8 @@ fn veh3d_real_update_wheel_transforms_ws(
 ///|
 fn veh3d_real_ray_cast(
   queries : @collision.QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
   chassis : @dynamics.RigidBody3D,
   wheel : Wheel3DReal,
 ) -> Wheel3DReal {
@@ -429,7 +431,8 @@ fn veh3d_real_ray_cast(
   out.raycast_info.contact_point_ws = source_ws.add(rayvector)
   let ray = @collision.Ray3::new(source_ws, rayvector)
   out.raycast_info.ground_object = None
-  if queries.cast_ray_and_get_normal(ray, 1.0F, true) is Some(hit) {
+  if queries.cast_ray_and_get_normal(bodies, colliders, ray, 1.0F, true)
+    is Some(hit) {
     let collider_hit = hit.0
     let intersection = hit.1
     let mut normal_ws = intersection.normal()
@@ -690,10 +693,12 @@ pub fn DynamicRayCastVehicleController3DReal::update_vehicle(
   self : DynamicRayCastVehicleController3DReal,
   dt : @core.Real,
   queries : @collision.QueryPipelineMut3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
 ) -> Unit {
-  queries.update()
+  queries.update(bodies, colliders)
   let qp = queries.as_ref()
-  let chassis = match qp.rigid_body(self.chassis) {
+  let chassis = match qp.rigid_body(bodies, self.chassis) {
     Some(rb) => rb
     None => return
   }
@@ -720,6 +725,8 @@ pub fn DynamicRayCastVehicleController3DReal::update_vehicle(
       qp.with_filter(
         @collision.QueryFilter3DReal::new().exclude_rigid_body(self.chassis),
       ),
+      bodies,
+      colliders,
       chassis,
       w,
     )
@@ -733,7 +740,7 @@ pub fn DynamicRayCastVehicleController3DReal::update_vehicle(
   }
 
   // Apply suspension impulses.
-  if qp.rigid_body_mut(self.chassis) is Some(rb) {
+  if qp.rigid_body_mut(bodies, self.chassis) is Some(rb) {
     for i in 0..<num_wheels {
       let w = self.wheels[i]
       if w.engine_force > 0.0F {
@@ -749,10 +756,10 @@ pub fn DynamicRayCastVehicleController3DReal::update_vehicle(
       rb.apply_impulse_at_point(impulse, w.raycast_info.contact_point_ws, false)
     }
   }
-  veh3d_real_update_friction(self, qp.bodies, qp.colliders, dt)
+  veh3d_real_update_friction(self, bodies, colliders, dt)
 
   // Update wheel rotation.
-  if qp.rigid_body_mut(self.chassis) is Some(rb) {
+  if qp.rigid_body_mut(bodies, self.chassis) is Some(rb) {
     let fwd_axis = rb
       .rotation()
       .rotate_vec3(veh3d_real_axis_vec3(self.index_forward_axis))

--- a/control/ray_cast_vehicle_controller_test.mbt
+++ b/control/ray_cast_vehicle_controller_test.mbt
@@ -77,7 +77,7 @@ test "raycast vehicle controller: accelerates on flat ground (2D)" {
   for _ in 0..<240 {
     let filter = @collision.QueryFilter::new().exclude_rigid_body(chassis)
     let queries = @collision.QueryPipelineMut::new(filter, bodies, colliders)
-    vehicle.update_vehicle(dt, queries)
+    vehicle.update_vehicle(dt, queries, bodies, colliders)
     pipeline.step(
       gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders,
       impulse_joints, multibody_joints, ccd_solver, hooks, events,
@@ -87,7 +87,7 @@ test "raycast vehicle controller: accelerates on flat ground (2D)" {
   // Refresh wheel contact info without adding impulses.
   let filter = @collision.QueryFilter::new().exclude_rigid_body(chassis)
   let queries = @collision.QueryPipelineMut::new(filter, bodies, colliders)
-  vehicle.update_vehicle(0.0F, queries)
+  vehicle.update_vehicle(0.0F, queries, bodies, colliders)
   inspect(vehicle.wheels.length() == 2, content="true")
   inspect(vehicle.wheels[0].raycast_info().is_in_contact, content="true")
   if bodies.get(chassis) is Some(rb) {
@@ -179,7 +179,7 @@ test "raycast vehicle controller: climbs a mild slope (2D port)" {
   for _ in 0..<480 {
     let filter = @collision.QueryFilter::new().exclude_rigid_body(chassis)
     let queries = @collision.QueryPipelineMut::new(filter, bodies, colliders)
-    vehicle.update_vehicle(dt, queries)
+    vehicle.update_vehicle(dt, queries, bodies, colliders)
     pipeline.step(
       gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders,
       impulse_joints, multibody_joints, ccd_solver, hooks, events,
@@ -268,7 +268,7 @@ test "raycast vehicle controller: braking reduces forward speed (2D)" {
   for _ in 0..<180 {
     let filter = @collision.QueryFilter::new().exclude_rigid_body(chassis)
     let queries = @collision.QueryPipelineMut::new(filter, bodies, colliders)
-    vehicle.update_vehicle(dt, queries)
+    vehicle.update_vehicle(dt, queries, bodies, colliders)
     pipeline.step(
       gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders,
       impulse_joints, multibody_joints, ccd_solver, hooks, events,
@@ -288,7 +288,7 @@ test "raycast vehicle controller: braking reduces forward speed (2D)" {
   for _ in 0..<180 {
     let filter = @collision.QueryFilter::new().exclude_rigid_body(chassis)
     let queries = @collision.QueryPipelineMut::new(filter, bodies, colliders)
-    vehicle.update_vehicle(dt, queries)
+    vehicle.update_vehicle(dt, queries, bodies, colliders)
     pipeline.step(
       gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders,
       impulse_joints, multibody_joints, ccd_solver, hooks, events,

--- a/control/spec.mbt
+++ b/control/spec.mbt
@@ -262,6 +262,8 @@ pub fn KinematicCharacterController::move_shape(
   self : KinematicCharacterController,
   dt : @core.Real,
   query : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   shape : @collision.Shape,
   position : @core.Isometry2,
   translation : @core.Vec2,
@@ -276,6 +278,8 @@ pub fn KinematicCharacterController::solve_character_collision_impulses(
   self : KinematicCharacterController,
   dt : @core.Real,
   query : @collision.QueryPipeline,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
   character_shape : @collision.Shape,
   character_mass : @core.Real,
   collisions : Array[CharacterCollision],
@@ -601,6 +605,8 @@ pub fn DynamicRayCastVehicleController::update_vehicle(
   self : DynamicRayCastVehicleController,
   dt : @core.Real,
   queries : @collision.QueryPipelineMut,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
 ) -> Unit {
   ...
 }
@@ -714,6 +720,8 @@ pub fn DynamicRayCastVehicleController3::update_vehicle(
   self : DynamicRayCastVehicleController3,
   dt : @core.Real,
   queries : @collision.QueryPipelineMut,
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
 ) -> Unit {
   ...
 }
@@ -792,6 +800,8 @@ pub fn DynamicRayCastVehicleController3DReal::update_vehicle(
   self : DynamicRayCastVehicleController3DReal,
   dt : @core.Real,
   queries : @collision.QueryPipelineMut3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
 ) -> Unit {
   ...
 }
@@ -962,6 +972,8 @@ pub fn KinematicCharacterController3DReal::move_shape(
   self : KinematicCharacterController3DReal,
   dt : @core.Real,
   query : @collision.QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
   shape : @collision.Shape3D,
   position : @core.Isometry3,
   translation : @core.Vec3,
@@ -976,6 +988,8 @@ pub fn KinematicCharacterController3DReal::solve_character_collision_impulses(
   self : KinematicCharacterController3DReal,
   dt : @core.Real,
   query : @collision.QueryPipeline3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : @collision.ColliderSet3D,
   character_shape : @collision.Shape3D,
   character_mass : @core.Real,
   collisions : Array[CharacterCollision3DReal],

--- a/pipeline/ccd.mbt
+++ b/pipeline/ccd.mbt
@@ -146,7 +146,15 @@ fn predict_ccd_impacts_at_next_positions(
           let pipeline = @collision.QueryPipeline::new(
             filter, bodies, colliders,
           )
-          if pipeline.cast_shape_nonlinear(motion, co.shape, 0.0F, dt, true)
+          if pipeline.cast_shape_nonlinear(
+              bodies,
+              colliders,
+              motion,
+              co.shape,
+              0.0F,
+              dt,
+              true,
+            )
             is Some((_, hit)) {
             let toi = hit.toi()
             best_toi = match best_toi {
@@ -264,6 +272,8 @@ fn find_first_ccd_impact(
             filter, bodies, colliders,
           )
           if pipeline.cast_shape_nonlinear(
+              bodies,
+              colliders,
               motion,
               co.shape,
               0.0F,

--- a/rapier_full/examples2d_parity_test.mbt
+++ b/rapier_full/examples2d_parity_test.mbt
@@ -1070,6 +1070,8 @@ test "examples2d/character_controller2.rs parity" {
         let movement = controller.move_shape(
           dt,
           query_pipeline,
+          bodies,
+          colliders,
           character_shape,
           character_body.position(),
           desired,
@@ -1081,6 +1083,8 @@ test "examples2d/character_controller2.rs parity" {
           controller.solve_character_collision_impulses(
             dt,
             query_pipeline,
+            bodies,
+            colliders,
             character_shape,
             character_body.mass(),
             collisions,
@@ -1642,6 +1646,8 @@ test "examples2d/debug_intersection2.rs parity" {
   let query_pipeline = broad_phase.as_query_pipeline(bodies, colliders, filter)
   let query_center = @core.Vec2::zero()
   let hits = query_pipeline.intersect_shape(
+    bodies,
+    colliders,
     @core.Isometry2::from_translation(query_center),
     @collision.Shape::Ball(rad / 2.0F),
   )

--- a/rapier_full/examples3d_parity_test.mbt
+++ b/rapier_full/examples3d_parity_test.mbt
@@ -1351,7 +1351,7 @@ fn run_examples3d_vehicle_controller3() -> Bool {
   for _ in 0..<240 {
     let filter = @collision.QueryFilter::new().exclude_rigid_body(chassis)
     let queries = @collision.QueryPipelineMut::new3(filter, bodies, colliders)
-    vehicle.update_vehicle(dt, queries)
+    vehicle.update_vehicle(dt, queries, bodies.as_2d(), colliders.as_2d())
     pipeline.step(
       gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders,
       impulse_joints, multibody_joints, ccd_solver, hooks, events,

--- a/rapier_full/examples3d_real_character_controller_parity_test.mbt
+++ b/rapier_full/examples3d_real_character_controller_parity_test.mbt
@@ -261,7 +261,7 @@ test "examples3d/character_controller3.rs parity (3DReal headless)" {
       rb.set_linvel(linvel)
     }
     colliders.sync_with_bodies(bodies)
-    queries.update()
+    queries.update(bodies, colliders)
     let qp = queries
       .as_ref()
       .with_filter(
@@ -272,6 +272,8 @@ test "examples3d/character_controller3.rs parity (3DReal headless)" {
       let movement = controller.move_shape(
         dt,
         qp,
+        bodies,
+        colliders,
         cc.shape(),
         cc.position(),
         @core.Vec3::new(speed * dt, 0.0F, 0.0F),
@@ -280,6 +282,8 @@ test "examples3d/character_controller3.rs parity (3DReal headless)" {
       controller.solve_character_collision_impulses(
         dt,
         qp,
+        bodies,
+        colliders,
         cc.shape(),
         1.0F,
         collisions,

--- a/rapier_full/examples3d_real_urdf_keva_voxels_parity_test.mbt
+++ b/rapier_full/examples3d_real_urdf_keva_voxels_parity_test.mbt
@@ -327,7 +327,8 @@ test "examples3d/voxels3.rs parity (3DReal headless)" {
     ),
     @core.Vec3::new(0.0F, -1.0F, 0.0F),
   )
-  if qp0.cast_ray_and_get_voxel_key(ray0, 200.0F, true) is Some((_, _, _)) {
+  if qp0.cast_ray_and_get_voxel_key(bodies, colliders, ray0, 200.0F, true)
+    is Some((_, _, _)) {
     inspect(true, content="true")
   } else {
     inspect(false, content="true")

--- a/rapier_full/examples3d_real_vehicle_controller_parity_test.mbt
+++ b/rapier_full/examples3d_real_vehicle_controller_parity_test.mbt
@@ -193,7 +193,7 @@ test "examples3d/vehicle_controller3.rs parity (3DReal headless)" {
     colliders,
   )
   for _ in 0..<240 {
-    vehicle.update_vehicle(dt, queries)
+    vehicle.update_vehicle(dt, queries, bodies, colliders)
     pipeline.step(
       gravity, parameters, islands, broad_phase, narrow_phase, bodies, colliders,
     )


### PR DESCRIPTION
Fixes #12.\n\n- Remove placeholder dispatcher from public API.\n- QueryPipeline/QueryPipeline3DReal no longer own copies of RigidBodySet/ColliderSet; callers pass sets explicitly.\n- Update character controller, vehicle controller, CCD, and parity tests accordingly.\n\nTests: moon test --frozen