### PR TITLE
Fix #13: true 2D rounded shapes

### DIFF
--- a/collision/broad_phase_bvh_test.mbt
+++ b/collision/broad_phase_bvh_test.mbt
@@ -154,6 +154,8 @@ fn compute_aabb_for_test(
 ) -> (@core.Vec2, @core.Vec2) {
   let pd = if prediction_distance < 0.0F { 0.0F } else { prediction_distance }
   match shape {
+    Shape::Round(inner, radius) =>
+      compute_aabb_for_test(inner.val, center, rotation, pd + radius)
     Shape::Ball(radius) => {
       let r = radius + pd
       (

--- a/collision/collider_set.mbt
+++ b/collision/collider_set.mbt
@@ -439,6 +439,7 @@ pub(all) enum Shape {
   ConvexPolygon(Array[@core.Vec2])
   TriMesh(Array[@core.Vec2], Array[(Int, Int, Int)])
   Compound(Array[(@core.Isometry2, Shape)])
+  Round(Ref[Shape], @core.Real)
 }
 
 ///|
@@ -588,6 +589,57 @@ pub fn ColliderBuilder::default_friction() -> @core.Real {
 }
 
 ///|
+fn clamp_nonnegative_radius(radius : @core.Real) -> @core.Real {
+  if radius < 0.0F {
+    0.0F
+  } else {
+    radius
+  }
+}
+
+///|
+fn collider_builder_rebuild_with_shape(
+  builder : ColliderBuilder,
+  shape : Shape,
+) -> ColliderBuilder {
+  {
+    shape,
+    translation: builder.translation,
+    rotation: builder.rotation,
+    active_collision_types: builder.active_collision_types,
+    sensor: builder.sensor,
+    active_events: builder.active_events,
+    active_hooks: builder.active_hooks,
+    collision_groups: builder.collision_groups,
+    solver_groups: builder.solver_groups,
+    density: builder.density,
+    friction: builder.friction,
+    friction_combine_rule: builder.friction_combine_rule,
+    restitution: builder.restitution,
+    restitution_combine_rule: builder.restitution_combine_rule,
+    contact_skin: builder.contact_skin,
+    contact_force_event_threshold: builder.contact_force_event_threshold,
+    user_data: builder.user_data,
+    enabled: builder.enabled,
+  }
+}
+
+///|
+fn collider_builder_rounded(
+  builder : ColliderBuilder,
+  border_radius : @core.Real,
+) -> ColliderBuilder {
+  let r = clamp_nonnegative_radius(border_radius)
+  if r <= 0.0F {
+    return builder
+  }
+  collider_builder_rebuild_with_shape(
+    builder,
+    Shape::Round(Ref::new(builder.shape), r),
+  )
+}
+
+///|
 pub fn ColliderBuilder::ball(radius : @core.Real) -> ColliderBuilder {
   {
     shape: Shape::Ball(radius),
@@ -644,7 +696,10 @@ pub fn ColliderBuilder::round_cuboid(
   half_height : @core.Real,
   border_radius : @core.Real,
 ) -> ColliderBuilder {
-  ColliderBuilder::cuboid(half_width, half_height).contact_skin(border_radius)
+  collider_builder_rounded(
+    ColliderBuilder::cuboid(half_width, half_height),
+    border_radius,
+  )
 }
 
 ///|
@@ -773,7 +828,7 @@ pub fn ColliderBuilder::round_triangle(
   c : @core.Vec2,
   border_radius : @core.Real,
 ) -> ColliderBuilder {
-  ColliderBuilder::triangle(a, b, c).contact_skin(border_radius)
+  collider_builder_rounded(ColliderBuilder::triangle(a, b, c), border_radius)
 }
 
 ///|
@@ -808,7 +863,7 @@ pub fn ColliderBuilder::round_convex_hull(
   border_radius : @core.Real,
 ) -> ColliderBuilder? {
   if ColliderBuilder::convex_hull(points) is Some(builder) {
-    Some(builder.contact_skin(border_radius))
+    Some(collider_builder_rounded(builder, border_radius))
   } else {
     None
   }
@@ -1007,7 +1062,8 @@ pub fn ColliderBuilder::round_convex_decomposition_with_params(
   params : VHACDParameters,
   border_radius : @core.Real,
 ) -> ColliderBuilder {
-  ColliderBuilder::convex_decomposition_with_params(vertices, indices, params).contact_skin(
+  collider_builder_rounded(
+    ColliderBuilder::convex_decomposition_with_params(vertices, indices, params),
     border_radius,
   )
 }
@@ -1062,7 +1118,7 @@ pub fn ColliderBuilder::round_convex_polyline(
 ) -> ColliderBuilder? {
   match ColliderBuilder::convex_polyline(points) {
     None => None
-    Some(builder) => Some(builder.contact_skin(border_radius))
+    Some(builder) => Some(collider_builder_rounded(builder, border_radius))
   }
 }
 
@@ -1747,6 +1803,7 @@ fn shape_mass_properties(
       let inertia = inertia_rect + 2.0F * inertia_semi_origin
       @core.MassProperties::new(mass, inertia, @core.Vec2::zero())
     }
+    Shape::Round(inner, _) => shape_mass_properties(inner.val, density)
     Shape::Segment(a, b) => {
       // Like Rapier/Parry: segments have no area, so they don't contribute to mass properties.
       let com = @core.Vec2::new((a.x + b.x) * 0.5F, (a.y + b.y) * 0.5F)
@@ -2321,6 +2378,13 @@ fn write_triples(sb : StringBuilder, triples : Array[(Int, Int, Int)]) -> Unit {
 ///|
 fn write_shape(sb : StringBuilder, shape : Shape) -> Unit {
   match shape {
+    Shape::Round(inner, radius) => {
+      sb.write_string("r(")
+      write_shape(sb, inner.val)
+      sb.write_char(',')
+      sb.write_object(radius)
+      sb.write_char(')')
+    }
     Shape::Ball(r) => {
       sb.write_string("b(")
       sb.write_object(r)
@@ -2462,7 +2526,17 @@ fn parse_triples(text : String) -> Array[(Int, Int, Int)] {
 
 ///|
 fn parse_shape(text : String) -> Shape {
-  if text.strip_prefix("b("[:]) is Some(v) &&
+  if text.strip_prefix("r("[:]) is Some(v) &&
+    v.strip_suffix(")"[:]) is Some(inner) {
+    let parts = split_top_level(inner.to_string(), ',')
+    if parts.length() >= 2 {
+      let base = parse_shape(parts[0])
+      let radius = parse_real_value(parts[1])
+      Shape::Round(Ref::new(base), radius)
+    } else {
+      Shape::Round(Ref::new(parse_shape(inner.to_string())), 0.0F)
+    }
+  } else if text.strip_prefix("b("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
     Shape::Ball(parse_real_value(inner.to_string()))
   } else if text.strip_prefix("c("[:]) is Some(v) &&
@@ -2943,30 +3017,6 @@ fn is_same_parent(left : Collider, right : Collider) -> Bool {
 }
 
 ///|
-fn update_collider_world_pose(
-  collider : Collider,
-  bodies : @dynamics.RigidBodySet,
-) -> Collider {
-  if collider.parent is Some(parent) {
-    if bodies.get(parent) is Some(body) {
-      // Rapier semantics: world_position = body_position * local_position_wrt_parent.
-      let body_pos = body.position()
-      let local_pos = @core.Isometry2::new(
-        collider.local_translation,
-        @core.Rot2::from_angle(collider.local_rotation),
-      )
-      let world_pos = body_pos.mul(local_pos)
-      collider.world_translation = world_pos.translation
-      collider.world_rotation = world_pos.rotation.angle()
-      return collider
-    }
-  }
-  collider.world_translation = collider.local_translation
-  collider.world_rotation = collider.local_rotation
-  collider
-}
-
-///|
 fn ColliderSet::push_modified_unchecked(
   self : ColliderSet,
   handle : ColliderHandle,
@@ -2994,7 +3044,22 @@ fn ColliderSet::sync_with_bodies(
 ) -> Unit {
   for i in 0..<self.colliders.length() {
     if self.colliders[i] is Some(collider) {
-      self.colliders[i] = Some(update_collider_world_pose(collider, bodies))
+      if collider.parent is Some(parent) {
+        if bodies.get(parent) is Some(body) {
+          // Rapier semantics: world_position = body_position * local_position_wrt_parent.
+          let body_pos = body.position()
+          let local_pos = @core.Isometry2::new(
+            collider.local_translation,
+            @core.Rot2::from_angle(collider.local_rotation),
+          )
+          let world_pos = body_pos.mul(local_pos)
+          collider.world_translation = world_pos.translation
+          collider.world_rotation = world_pos.rotation.angle()
+          continue
+        }
+      }
+      collider.world_translation = collider.local_translation
+      collider.world_rotation = collider.local_rotation
     }
   }
 }
@@ -3071,8 +3136,21 @@ pub fn ColliderSet::insert_with_parent(
   let updated = collider
   updated.changes = ColliderChanges::all()
   updated.parent = Some(parent)
-  let updated_world = update_collider_world_pose(updated, bodies)
-  self.colliders[handle.id] = Some(updated_world)
+  if bodies.get(parent) is Some(body) {
+    // Rapier semantics: world_position = body_position * local_position_wrt_parent.
+    let body_pos = body.position()
+    let local_pos = @core.Isometry2::new(
+      updated.local_translation,
+      @core.Rot2::from_angle(updated.local_rotation),
+    )
+    let world_pos = body_pos.mul(local_pos)
+    updated.world_translation = world_pos.translation
+    updated.world_rotation = world_pos.rotation.angle()
+  } else {
+    updated.world_translation = updated.local_translation
+    updated.world_rotation = updated.local_rotation
+  }
+  self.colliders[handle.id] = Some(updated)
   if self.colliders[handle.id] is Some(collider_ref) {
     self.push_modified_unchecked(handle, collider_ref)
   }
@@ -3231,12 +3309,26 @@ pub fn ColliderSet::set_parent(
     let old_parent = collider.parent
     collider.parent = parent
     collider.changes = collider.changes.insert(COLLIDER_CHANGES_PARENT)
-    self.colliders[handle.id] = Some(
-      update_collider_world_pose(collider, bodies),
-    )
-    if self.colliders[handle.id] is Some(updated) {
-      self.push_modified(handle, updated)
+    if collider.parent is Some(parent) {
+      if bodies.get(parent) is Some(body) {
+        // Rapier semantics: world_position = body_position * local_position_wrt_parent.
+        let body_pos = body.position()
+        let local_pos = @core.Isometry2::new(
+          collider.local_translation,
+          @core.Rot2::from_angle(collider.local_rotation),
+        )
+        let world_pos = body_pos.mul(local_pos)
+        collider.world_translation = world_pos.translation
+        collider.world_rotation = world_pos.rotation.angle()
+      } else {
+        collider.world_translation = collider.local_translation
+        collider.world_rotation = collider.local_rotation
+      }
+    } else {
+      collider.world_translation = collider.local_translation
+      collider.world_rotation = collider.local_rotation
     }
+    self.push_modified(handle, collider)
     // Update mass properties immediately for both the old and new parent, so impulses applied
     // before the next pipeline step behave like Rapier.
     if old_parent is Some(old_rb) {
@@ -3294,11 +3386,26 @@ pub fn handle_user_changes_to_colliders(
       let changes = collider.changes
       let parent = collider.parent
       if changes.contains(COLLIDER_CHANGES_PARENT) {
-        let updated = update_collider_world_pose(collider, bodies)
-        updated.changes = updated.changes.insert(COLLIDER_CHANGES_POSITION)
-        if handle.id >= 0 && handle.id < colliders.colliders.length() {
-          colliders.colliders[handle.id] = Some(updated)
+        if collider.parent is Some(parent) {
+          if bodies.get(parent) is Some(body) {
+            // Rapier semantics: world_position = body_position * local_position_wrt_parent.
+            let body_pos = body.position()
+            let local_pos = @core.Isometry2::new(
+              collider.local_translation,
+              @core.Rot2::from_angle(collider.local_rotation),
+            )
+            let world_pos = body_pos.mul(local_pos)
+            collider.world_translation = world_pos.translation
+            collider.world_rotation = world_pos.rotation.angle()
+          } else {
+            collider.world_translation = collider.local_translation
+            collider.world_rotation = collider.local_rotation
+          }
+        } else {
+          collider.world_translation = collider.local_translation
+          collider.world_rotation = collider.local_rotation
         }
+        collider.changes = collider.changes.insert(COLLIDER_CHANGES_POSITION)
       }
       if changes.contains(COLLIDER_CHANGES_PARENT) ||
         changes.contains(COLLIDER_CHANGES_SHAPE) ||
@@ -3554,6 +3661,31 @@ fn shapes_intersect(
   pos2 : @core.Vec2,
   rot2 : @core.Real,
 ) -> Bool {
+  match (shape1, shape2) {
+    (Shape::Round(_, _), _) | (_, Shape::Round(_, _)) => {
+      // For rounded shapes, reuse the contact-manifold logic for overlap testing.
+      // This keeps the overlap semantics consistent with `build_contact_pair`.
+      let c1 = ColliderBuilder::new(shape1)
+        .translation(pos1)
+        .rotation(rot1)
+        .build()
+      let c2 = ColliderBuilder::new(shape2)
+        .translation(pos2)
+        .rotation(rot2)
+        .build()
+      let pair = build_contact_pair(0.0F, c1, c2)
+      for mi in 0..<pair.manifolds.length() {
+        let manifold = pair.manifolds[mi]
+        for pi in 0..<manifold.points.length() {
+          if manifold.points[pi].dist <= 0.0F {
+            return true
+          }
+        }
+      }
+      return false
+    }
+    _ => ()
+  }
   fn cross2(a : @core.Vec2, b : @core.Vec2) -> @core.Real {
     a.x * b.y - a.y * b.x
   }
@@ -6259,56 +6391,117 @@ fn build_contact_pair(
     c1 : Collider,
     c2 : Collider,
   ) -> Array[ContactManifold] {
+    fn unwrap_round_shape(shape : Shape) -> (Shape, @core.Real) {
+      match shape {
+        Shape::Round(inner, radius) => {
+          let (base, r) = unwrap_round_shape(inner.val)
+          (base, r + clamp_nonnegative_radius(radius))
+        }
+        _ => (shape, 0.0F)
+      }
+    }
+
+    fn apply_rounding_to_manifold(
+      manifold : ContactManifold,
+      collider1 : Collider,
+      collider2 : Collider,
+      radius1 : @core.Real,
+      radius2 : @core.Real,
+    ) -> ContactManifold {
+      if radius1 <= 0.0F && radius2 <= 0.0F {
+        return manifold
+      }
+      let p1_inv = collider1.position().inverse()
+      let p2_inv = collider2.position().inverse()
+      let n = manifold.normal
+      let shift1 = vec2_scale(n, radius1)
+      let shift2 = vec2_scale(n, radius2)
+      let out_pts : Array[ContactManifoldPoint] = []
+      for i in 0..<manifold.points.length() {
+        let p = manifold.points[i]
+        let world_p1 = collider1
+          .position()
+          .transform_point(p.local_p1)
+          .add(shift1)
+        let world_p2 = collider2
+          .position()
+          .transform_point(p.local_p2)
+          .sub(shift2)
+        out_pts.push(ContactManifoldPoint::{
+          local_p1: p1_inv.transform_point(world_p1),
+          local_p2: p2_inv.transform_point(world_p2),
+          dist: p.dist - (radius1 + radius2),
+          fid1: p.fid1,
+          fid2: p.fid2,
+        })
+      }
+      ContactManifold::{ normal: n, points: out_pts }
+    }
+
+    let (shape1, radius1) = unwrap_round_shape(c1.shape)
+    let (shape2, radius2) = unwrap_round_shape(c2.shape)
+    let c1_base = c1
+    c1_base.shape = shape1
+    let c2_base = c2
+    c2_base.shape = shape2
     let out : Array[ContactManifold] = []
-    match (c1.shape, c2.shape) {
+    match (shape1, shape2) {
       (Shape::Ball(r1), Shape::Ball(r2)) =>
-        out.push(contact_manifold_ball_ball(c1, r1, c2, r2))
+        out.push(contact_manifold_ball_ball(c1_base, r1, c2_base, r2))
       (Shape::Ball(r), Shape::Cuboid(hw, hh)) =>
-        out.push(contact_manifold_ball_cuboid(c1, r, c2, hw, hh))
+        out.push(contact_manifold_ball_cuboid(c1_base, r, c2_base, hw, hh))
       (Shape::Ball(r), Shape::ConvexPolygon(vertices)) =>
-        out.push(contact_manifold_ball_convex_polygon(c1, r, c2, vertices))
+        out.push(
+          contact_manifold_ball_convex_polygon(c1_base, r, c2_base, vertices),
+        )
       (Shape::Cuboid(hw, hh), Shape::Ball(r)) =>
-        out.push(contact_manifold_cuboid_ball(c1, hw, hh, c2, r))
+        out.push(contact_manifold_cuboid_ball(c1_base, hw, hh, c2_base, r))
       (Shape::ConvexPolygon(vertices), Shape::Ball(r)) =>
-        out.push(contact_manifold_convex_polygon_ball(c1, vertices, c2, r))
+        out.push(
+          contact_manifold_convex_polygon_ball(c1_base, vertices, c2_base, r),
+        )
       (Shape::Cuboid(hw1, hh1), Shape::Cuboid(hw2, hh2)) =>
         out.push(
           contact_manifold_cuboid_cuboid(
-            c1, hw1, hh1, c2, hw2, hh2, prediction_distance,
+            c1_base, hw1, hh1, c2_base, hw2, hh2, prediction_distance,
           ),
         )
       (Shape::ConvexPolygon(vertices1), Shape::ConvexPolygon(vertices2)) =>
         out.push(
           contact_manifold_convex_polygon_convex_polygon(
-            c1, vertices1, c2, vertices2, prediction_distance,
+            c1_base, vertices1, c2_base, vertices2, prediction_distance,
           ),
         )
       (Shape::ConvexPolygon(vertices), Shape::Cuboid(hw, hh)) =>
         out.push(
           contact_manifold_convex_polygon_cuboid(
-            c1, vertices, c2, hw, hh, prediction_distance,
+            c1_base, vertices, c2_base, hw, hh, prediction_distance,
           ),
         )
       (Shape::Cuboid(hw, hh), Shape::ConvexPolygon(vertices)) =>
         out.push(
           contact_manifold_cuboid_convex_polygon(
-            c1, hw, hh, c2, vertices, prediction_distance,
+            c1_base, hw, hh, c2_base, vertices, prediction_distance,
           ),
         )
       (Shape::Ball(r), Shape::Segment(a, b)) =>
-        out.push(contact_manifold_ball_segment(c1, r, c2, a, b))
+        out.push(contact_manifold_ball_segment(c1_base, r, c2_base, a, b))
       (Shape::Segment(a, b), Shape::Ball(r)) =>
-        out.push(contact_manifold_segment_ball(c1, a, b, c2, r))
+        out.push(contact_manifold_segment_ball(c1_base, a, b, c2_base, r))
       (Shape::Ball(r), Shape::Polyline(vertices, indices)) =>
-        out.push(contact_manifold_ball_polyline(c1, r, c2, vertices, indices))
+        out.push(
+          contact_manifold_ball_polyline(c1_base, r, c2_base, vertices, indices),
+        )
       (Shape::Polyline(vertices, indices), Shape::Ball(r)) =>
-        out.push(contact_manifold_polyline_ball(c1, vertices, indices, c2, r))
+        out.push(
+          contact_manifold_polyline_ball(c1_base, vertices, indices, c2_base, r),
+        )
       (Shape::Ball(r), Shape::CapsuleX(hh, cr)) =>
         out.push(
           contact_manifold_ball_capsule(
-            c1,
+            c1_base,
             r,
-            c2,
+            c2_base,
             hh,
             cr,
             @core.Vec2::new(1.0F, 0.0F),
@@ -6317,9 +6510,9 @@ fn build_contact_pair(
       (Shape::Ball(r), Shape::CapsuleY(hh, cr)) =>
         out.push(
           contact_manifold_ball_capsule(
-            c1,
+            c1_base,
             r,
-            c2,
+            c2_base,
             hh,
             cr,
             @core.Vec2::new(0.0F, 1.0F),
@@ -6328,33 +6521,33 @@ fn build_contact_pair(
       (Shape::CapsuleX(hh, cr), Shape::Ball(r)) =>
         out.push(
           contact_manifold_capsule_ball(
-            c1,
+            c1_base,
             hh,
             cr,
             @core.Vec2::new(1.0F, 0.0F),
-            c2,
+            c2_base,
             r,
           ),
         )
       (Shape::CapsuleY(hh, cr), Shape::Ball(r)) =>
         out.push(
           contact_manifold_capsule_ball(
-            c1,
+            c1_base,
             hh,
             cr,
             @core.Vec2::new(0.0F, 1.0F),
-            c2,
+            c2_base,
             r,
           ),
         )
       (Shape::CapsuleX(hh1, r1), Shape::CapsuleX(hh2, r2)) =>
         out.push(
           contact_manifold_capsule_capsule(
-            c1,
+            c1_base,
             hh1,
             r1,
             @core.Vec2::new(1.0F, 0.0F),
-            c2,
+            c2_base,
             hh2,
             r2,
             @core.Vec2::new(1.0F, 0.0F),
@@ -6363,11 +6556,11 @@ fn build_contact_pair(
       (Shape::CapsuleX(hh1, r1), Shape::CapsuleY(hh2, r2)) =>
         out.push(
           contact_manifold_capsule_capsule(
-            c1,
+            c1_base,
             hh1,
             r1,
             @core.Vec2::new(1.0F, 0.0F),
-            c2,
+            c2_base,
             hh2,
             r2,
             @core.Vec2::new(0.0F, 1.0F),
@@ -6376,11 +6569,11 @@ fn build_contact_pair(
       (Shape::CapsuleY(hh1, r1), Shape::CapsuleX(hh2, r2)) =>
         out.push(
           contact_manifold_capsule_capsule(
-            c1,
+            c1_base,
             hh1,
             r1,
             @core.Vec2::new(0.0F, 1.0F),
-            c2,
+            c2_base,
             hh2,
             r2,
             @core.Vec2::new(1.0F, 0.0F),
@@ -6389,37 +6582,47 @@ fn build_contact_pair(
       (Shape::CapsuleY(hh1, r1), Shape::CapsuleY(hh2, r2)) =>
         out.push(
           contact_manifold_capsule_capsule(
-            c1,
+            c1_base,
             hh1,
             r1,
             @core.Vec2::new(0.0F, 1.0F),
-            c2,
+            c2_base,
             hh2,
             r2,
             @core.Vec2::new(0.0F, 1.0F),
           ),
         )
       (Shape::Segment(a, b), Shape::Cuboid(hw, hh)) =>
-        out.push(contact_manifold_segment_cuboid(c1, a, b, c2, hw, hh))
+        out.push(
+          contact_manifold_segment_cuboid(c1_base, a, b, c2_base, hw, hh),
+        )
       (Shape::Cuboid(hw, hh), Shape::Segment(a, b)) =>
-        out.push(contact_manifold_cuboid_segment(c1, hw, hh, c2, a, b))
+        out.push(
+          contact_manifold_cuboid_segment(c1_base, hw, hh, c2_base, a, b),
+        )
       (Shape::Polyline(vertices, indices), Shape::Cuboid(hw, hh)) =>
         out.push(
-          contact_manifold_polyline_cuboid(c1, vertices, indices, c2, hw, hh),
+          contact_manifold_polyline_cuboid(
+            c1_base, vertices, indices, c2_base, hw, hh,
+          ),
         )
       (Shape::Cuboid(hw, hh), Shape::Polyline(vertices, indices)) =>
         out.push(
-          contact_manifold_cuboid_polyline(c1, hw, hh, c2, vertices, indices),
+          contact_manifold_cuboid_polyline(
+            c1_base, hw, hh, c2_base, vertices, indices,
+          ),
         )
       (Shape::Segment(a1, b1), Shape::Segment(a2, b2)) =>
-        out.push(contact_manifold_segment_segment(c1, a1, b1, c2, a2, b2))
+        out.push(
+          contact_manifold_segment_segment(c1_base, a1, b1, c2_base, a2, b2),
+        )
       (Shape::Segment(a, b), Shape::CapsuleX(hh, cr)) =>
         out.push(
           contact_manifold_segment_capsule(
-            c1,
+            c1_base,
             a,
             b,
-            c2,
+            c2_base,
             hh,
             cr,
             @core.Vec2::new(1.0F, 0.0F),
@@ -6428,10 +6631,10 @@ fn build_contact_pair(
       (Shape::Segment(a, b), Shape::CapsuleY(hh, cr)) =>
         out.push(
           contact_manifold_segment_capsule(
-            c1,
+            c1_base,
             a,
             b,
-            c2,
+            c2_base,
             hh,
             cr,
             @core.Vec2::new(0.0F, 1.0F),
@@ -6440,11 +6643,11 @@ fn build_contact_pair(
       (Shape::CapsuleX(hh, cr), Shape::Segment(a, b)) =>
         out.push(
           contact_manifold_capsule_segment(
-            c1,
+            c1_base,
             hh,
             cr,
             @core.Vec2::new(1.0F, 0.0F),
-            c2,
+            c2_base,
             a,
             b,
           ),
@@ -6452,11 +6655,11 @@ fn build_contact_pair(
       (Shape::CapsuleY(hh, cr), Shape::Segment(a, b)) =>
         out.push(
           contact_manifold_capsule_segment(
-            c1,
+            c1_base,
             hh,
             cr,
             @core.Vec2::new(0.0F, 1.0F),
-            c2,
+            c2_base,
             a,
             b,
           ),
@@ -6464,11 +6667,11 @@ fn build_contact_pair(
       (Shape::CapsuleX(hh, cr), Shape::Cuboid(hw, hh2)) =>
         out.push(
           contact_manifold_capsule_cuboid(
-            c1,
+            c1_base,
             hh,
             cr,
             @core.Vec2::new(1.0F, 0.0F),
-            c2,
+            c2_base,
             hw,
             hh2,
           ),
@@ -6476,11 +6679,11 @@ fn build_contact_pair(
       (Shape::CapsuleY(hh, cr), Shape::Cuboid(hw, hh2)) =>
         out.push(
           contact_manifold_capsule_cuboid(
-            c1,
+            c1_base,
             hh,
             cr,
             @core.Vec2::new(0.0F, 1.0F),
-            c2,
+            c2_base,
             hw,
             hh2,
           ),
@@ -6488,10 +6691,10 @@ fn build_contact_pair(
       (Shape::Cuboid(hw, hh2), Shape::CapsuleX(hh, cr)) =>
         out.push(
           contact_manifold_cuboid_capsule(
-            c1,
+            c1_base,
             hw,
             hh2,
-            c2,
+            c2_base,
             hh,
             cr,
             @core.Vec2::new(1.0F, 0.0F),
@@ -6500,10 +6703,10 @@ fn build_contact_pair(
       (Shape::Cuboid(hw, hh2), Shape::CapsuleY(hh, cr)) =>
         out.push(
           contact_manifold_cuboid_capsule(
-            c1,
+            c1_base,
             hw,
             hh2,
-            c2,
+            c2_base,
             hh,
             cr,
             @core.Vec2::new(0.0F, 1.0F),
@@ -6511,7 +6714,17 @@ fn build_contact_pair(
         )
       _ => ()
     }
-    out
+    if radius1 <= 0.0F && radius2 <= 0.0F {
+      out
+    } else {
+      let adjusted : Array[ContactManifold] = []
+      for i in 0..<out.length() {
+        adjusted.push(
+          apply_rounding_to_manifold(out[i], c1_base, c2_base, radius1, radius2),
+        )
+      }
+      adjusted
+    }
   }
 
   fn map_manifold_points(
@@ -7122,6 +7335,13 @@ fn compute_shape_aabb(
 ) -> Aabb {
   let pd = if prediction_distance < 0.0F { 0.0F } else { prediction_distance }
   match shape {
+    Shape::Round(inner, radius) =>
+      compute_shape_aabb(
+        inner.val,
+        center,
+        rotation,
+        pd + clamp_nonnegative_radius(radius),
+      )
     Shape::Ball(radius) => {
       let r = radius + pd
       Aabb::{

--- a/collision/collider_test.mbt
+++ b/collision/collider_test.mbt
@@ -132,7 +132,11 @@ test "collider builder: triangle + round_triangle" {
     _ => inspect(false, content="true")
   }
   let round = ColliderBuilder::round_triangle(a, b, c, 0.2F).build()
-  inspect(@core.abs(round.contact_skin() - 0.2F) < 1.0e-6F, content="true")
+  inspect(round.contact_skin() == 0.0F, content="true")
+  match round.shape() {
+    Shape::Round(_, r) => inspect(@core.abs(r - 0.2F) < 1.0e-6F, content="true")
+    _ => inspect(false, content="true")
+  }
 }
 
 ///|
@@ -178,7 +182,12 @@ test "collider builder: compound + round_convex_hull" {
   ]
   if ColliderBuilder::round_convex_hull(pts, 0.3F) is Some(builder) {
     let collider = builder.build()
-    inspect(@core.abs(collider.contact_skin() - 0.3F) < 1.0e-6F, content="true")
+    inspect(collider.contact_skin() == 0.0F, content="true")
+    match collider.shape() {
+      Shape::Round(_, r) =>
+        inspect(@core.abs(r - 0.3F) < 1.0e-6F, content="true")
+      _ => inspect(false, content="true")
+    }
   } else {
     inspect(false, content="true")
   }

--- a/collision/pkg.generated.mbti
+++ b/collision/pkg.generated.mbti
@@ -1081,6 +1081,7 @@ pub(all) enum Shape {
   ConvexPolygon(Array[@core.Vec2])
   TriMesh(Array[@core.Vec2], Array[(Int, Int, Int)])
   Compound(Array[(@core.Isometry2, Shape)])
+  Round(Ref[Shape], Float)
 }
 pub fn Shape::voxelized_mesh(Array[@core.Vec2], Array[(Int, Int)], Float, FillMode) -> Self
 

--- a/collision/query_pipeline.mbt
+++ b/collision/query_pipeline.mbt
@@ -1771,6 +1771,7 @@ pub fn QueryPipeline::cast_shape(
       Shape::Cuboid(hw + target_distance, hh + target_distance)
     Shape::CapsuleX(h, r) => Shape::CapsuleX(h, r + target_distance)
     Shape::CapsuleY(h, r) => Shape::CapsuleY(h, r + target_distance)
+    Shape::Round(inner, r) => Shape::Round(inner, r + target_distance)
     Shape::Segment(_, _) => shape
     Shape::Polyline(_, _) => shape
     Shape::ConvexPolygon(_) => shape
@@ -1826,6 +1827,41 @@ pub fn QueryPipeline::cast_shape(
               best = best_hit(best, cast_against_target(p, r, part_shape))
             }
             best
+          }
+          Shape::Round(inner, radius) => {
+            let r = if radius < 0.0F { 0.0F } else { radius }
+            if r <= 0.0F {
+              cast_against_target(target_center, target_rotation, inner.val)
+            } else {
+              match inner.val {
+                Shape::Ball(br) =>
+                  cast_against_target(
+                    target_center,
+                    target_rotation,
+                    Shape::Ball(br + r),
+                  )
+                Shape::Cuboid(hw, hh) =>
+                  cast_against_target(
+                    target_center,
+                    target_rotation,
+                    Shape::Cuboid(hw + r, hh + r),
+                  )
+                Shape::CapsuleX(h, cr) =>
+                  cast_against_target(
+                    target_center,
+                    target_rotation,
+                    Shape::CapsuleX(h, cr + r),
+                  )
+                Shape::CapsuleY(h, cr) =>
+                  cast_against_target(
+                    target_center,
+                    target_rotation,
+                    Shape::CapsuleY(h, cr + r),
+                  )
+                _ =>
+                  cast_against_target(target_center, target_rotation, inner.val)
+              }
+            }
           }
           Shape::Segment(a, b) => {
             let (sa, sb) = segment_world_endpoints(
@@ -2154,6 +2190,8 @@ pub fn QueryPipeline::cast_shape_nonlinear(
   }
   fn shape_bounding_radius(shape : Shape) -> @core.Real {
     match shape {
+      Shape::Round(inner, r) =>
+        shape_bounding_radius(inner.val) + (if r < 0.0F { 0.0F } else { r })
       Shape::Ball(r) => r
       Shape::Cuboid(hw, hh) => sqrt_real(hw * hw + hh * hh)
       Shape::CapsuleX(h, r) => h + r
@@ -2236,6 +2274,14 @@ pub fn QueryPipeline::cast_shape_nonlinear(
     point : @core.Vec2,
   ) -> @core.Vec2 {
     match shape {
+      Shape::Round(inner, r) =>
+        project_point_on_shape(
+          center,
+          rotation,
+          Shape::Round(inner, r),
+          point,
+          false,
+        ).point
       Shape::Ball(r) => project_point_on_ball(center, r, point, false).point
       Shape::Cuboid(hw, hh) =>
         project_point_on_cuboid_oriented(center, rotation, hw, hh, point, false).point
@@ -2553,6 +2599,25 @@ fn point_in_shape(
   point : @core.Vec2,
 ) -> Bool {
   match shape {
+    Shape::Round(inner, radius) => {
+      let r = if radius < 0.0F { 0.0F } else { radius }
+      if r <= 0.0F {
+        point_in_shape(inner.val, center, rotation, point)
+      } else {
+        let proj = project_point_on_shape(
+          center,
+          rotation,
+          inner.val,
+          point,
+          true,
+        )
+        if proj.is_inside {
+          true
+        } else {
+          point.sub(proj.point).length_squared() <= r * r
+        }
+      }
+    }
     Shape::Ball(radius) => point.sub(center).length_squared() <= radius * radius
     Shape::Cuboid(hw, hh) => {
       let rot = @core.Rot2::from_angle(rotation)
@@ -2646,195 +2711,7 @@ fn point_in_shape(
 
 ///|
 fn compute_collider_aabb(collider : Collider) -> @core.Aabb {
-  match collider.shape {
-    Shape::Ball(radius) => {
-      let c = collider.world_translation
-      @core.Aabb::new(
-        @core.Vec2::new(c.x - radius, c.y - radius),
-        @core.Vec2::new(c.x + radius, c.y + radius),
-      )
-    }
-    Shape::Cuboid(half_width, half_height) => {
-      let rot = @core.Rot2::from_angle(collider.world_rotation)
-      let abs_cos = @core.abs(rot.cos)
-      let abs_sin = @core.abs(rot.sin)
-      let hw = abs_cos * half_width + abs_sin * half_height
-      let hh = abs_sin * half_width + abs_cos * half_height
-      let c = collider.world_translation
-      @core.Aabb::new(
-        @core.Vec2::new(c.x - hw, c.y - hh),
-        @core.Vec2::new(c.x + hw, c.y + hh),
-      )
-    }
-    Shape::CapsuleX(half_height, radius) => {
-      let rot = @core.Rot2::from_angle(collider.world_rotation)
-      let offset = rot.rotate_vec2(@core.Vec2::new(half_height, 0.0F))
-      let c = collider.world_translation
-      let a = c.add(offset)
-      let b = c.sub(offset)
-      let min_x = if a.x < b.x { a.x } else { b.x }
-      let max_x = if a.x > b.x { a.x } else { b.x }
-      let min_y = if a.y < b.y { a.y } else { b.y }
-      let max_y = if a.y > b.y { a.y } else { b.y }
-      @core.Aabb::new(
-        @core.Vec2::new(min_x - radius, min_y - radius),
-        @core.Vec2::new(max_x + radius, max_y + radius),
-      )
-    }
-    Shape::CapsuleY(half_height, radius) => {
-      let rot = @core.Rot2::from_angle(collider.world_rotation)
-      let offset = rot.rotate_vec2(@core.Vec2::new(0.0F, half_height))
-      let c = collider.world_translation
-      let a = c.add(offset)
-      let b = c.sub(offset)
-      let min_x = if a.x < b.x { a.x } else { b.x }
-      let max_x = if a.x > b.x { a.x } else { b.x }
-      let min_y = if a.y < b.y { a.y } else { b.y }
-      let max_y = if a.y > b.y { a.y } else { b.y }
-      @core.Aabb::new(
-        @core.Vec2::new(min_x - radius, min_y - radius),
-        @core.Vec2::new(max_x + radius, max_y + radius),
-      )
-    }
-    Shape::Segment(a, b) => {
-      let (wa, wb) = segment_world_endpoints(
-        collider.world_translation,
-        collider.world_rotation,
-        a,
-        b,
-      )
-      let min_x = if wa.x < wb.x { wa.x } else { wb.x }
-      let max_x = if wa.x > wb.x { wa.x } else { wb.x }
-      let min_y = if wa.y < wb.y { wa.y } else { wb.y }
-      let max_y = if wa.y > wb.y { wa.y } else { wb.y }
-      @core.Aabb::new(
-        @core.Vec2::new(min_x, min_y),
-        @core.Vec2::new(max_x, max_y),
-      )
-    }
-    Shape::Polyline(vertices, _) =>
-      if vertices.length() == 0 {
-        @core.Aabb::new(collider.world_translation, collider.world_translation)
-      } else {
-        let rot = @core.Rot2::from_angle(collider.world_rotation)
-        let c = collider.world_translation
-        let mut min_x = 1.0e30F
-        let mut max_x = -1.0e30F
-        let mut min_y = 1.0e30F
-        let mut max_y = -1.0e30F
-        for i in 0..<vertices.length() {
-          let wp = c.add(rot.rotate_vec2(vertices[i]))
-          if wp.x < min_x {
-            min_x = wp.x
-          }
-          if wp.x > max_x {
-            max_x = wp.x
-          }
-          if wp.y < min_y {
-            min_y = wp.y
-          }
-          if wp.y > max_y {
-            max_y = wp.y
-          }
-        }
-        @core.Aabb::new(
-          @core.Vec2::new(min_x, min_y),
-          @core.Vec2::new(max_x, max_y),
-        )
-      }
-    Shape::ConvexPolygon(vertices) =>
-      if vertices.length() == 0 {
-        @core.Aabb::new(collider.world_translation, collider.world_translation)
-      } else {
-        let rot = @core.Rot2::from_angle(collider.world_rotation)
-        let c = collider.world_translation
-        let mut min_x = 1.0e30F
-        let mut max_x = -1.0e30F
-        let mut min_y = 1.0e30F
-        let mut max_y = -1.0e30F
-        for i in 0..<vertices.length() {
-          let wp = c.add(rot.rotate_vec2(vertices[i]))
-          if wp.x < min_x {
-            min_x = wp.x
-          }
-          if wp.x > max_x {
-            max_x = wp.x
-          }
-          if wp.y < min_y {
-            min_y = wp.y
-          }
-          if wp.y > max_y {
-            max_y = wp.y
-          }
-        }
-        @core.Aabb::new(
-          @core.Vec2::new(min_x, min_y),
-          @core.Vec2::new(max_x, max_y),
-        )
-      }
-    Shape::TriMesh(vertices, _) =>
-      if vertices.length() == 0 {
-        @core.Aabb::new(collider.world_translation, collider.world_translation)
-      } else {
-        let rot = @core.Rot2::from_angle(collider.world_rotation)
-        let c = collider.world_translation
-        let mut min_x = 1.0e30F
-        let mut max_x = -1.0e30F
-        let mut min_y = 1.0e30F
-        let mut max_y = -1.0e30F
-        for i in 0..<vertices.length() {
-          let wp = c.add(rot.rotate_vec2(vertices[i]))
-          if wp.x < min_x {
-            min_x = wp.x
-          }
-          if wp.x > max_x {
-            max_x = wp.x
-          }
-          if wp.y < min_y {
-            min_y = wp.y
-          }
-          if wp.y > max_y {
-            max_y = wp.y
-          }
-        }
-        @core.Aabb::new(
-          @core.Vec2::new(min_x, min_y),
-          @core.Vec2::new(max_x, max_y),
-        )
-      }
-    Shape::Compound(parts) =>
-      if parts.length() == 0 {
-        @core.Aabb::new(collider.world_translation, collider.world_translation)
-      } else {
-        let base_iso = @core.Isometry2::new(
-          collider.world_translation,
-          @core.Rot2::from_angle(collider.world_rotation),
-        )
-        let mut acc : @core.Aabb? = None
-        for i in 0..<parts.length() {
-          let (pose, part_shape) = parts[i]
-          let w = base_iso.mul(pose)
-          let part_collider = collider
-          part_collider.shape = part_shape
-          part_collider.world_translation = isometry2_translation(w)
-          part_collider.world_rotation = isometry2_rotation_angle(w)
-          let part_aabb = compute_collider_aabb(part_collider)
-          if acc is Some(existing) {
-            acc = Some(existing.combine(part_aabb))
-          } else {
-            acc = Some(part_aabb)
-          }
-        }
-        if acc is Some(aabb) {
-          aabb
-        } else {
-          @core.Aabb::new(
-            collider.world_translation,
-            collider.world_translation,
-          )
-        }
-      }
-  }
+  compute_query_shape_aabb(collider.position(), collider.shape)
 }
 
 ///|
@@ -2855,6 +2732,14 @@ fn compute_query_shape_aabb(
   let center = shape_pos.translation
   let rot = shape_pos.rotation
   match shape {
+    Shape::Round(inner, radius) => {
+      let r = if radius < 0.0F { 0.0F } else { radius }
+      let aabb = compute_query_shape_aabb(shape_pos, inner.val)
+      @core.Aabb::new(
+        @core.Vec2::new(aabb.mins.x - r, aabb.mins.y - r),
+        @core.Vec2::new(aabb.maxs.x + r, aabb.maxs.y + r),
+      )
+    }
     Shape::Ball(radius) =>
       @core.Aabb::new(
         @core.Vec2::new(center.x - radius, center.y - radius),
@@ -3583,6 +3468,106 @@ fn ray_intersect_shape_and_get_normal(
   solid : Bool,
 ) -> RayIntersection? {
   match shape {
+    Shape::Round(inner, radius) => {
+      let base = inner.val
+      let r = if radius < 0.0F { 0.0F } else { radius }
+      if r <= 0.0F {
+        return ray_intersect_shape_and_get_normal(
+          ray, center, rotation, base, max_dist, solid,
+        )
+      }
+      fn dist_to_inner(
+        inner : Shape,
+        center : @core.Vec2,
+        rotation : @core.Real,
+        point : @core.Vec2,
+      ) -> @core.Real {
+        let proj = project_point_on_shape(center, rotation, inner, point, true)
+        if proj.is_inside {
+          0.0F
+        } else {
+          point.sub(proj.point).length()
+        }
+      }
+
+      let mut start_dist = dist_to_inner(base, center, rotation, ray.origin)
+      if start_dist <= r {
+        if solid {
+          let normal = normalize_or_fallback(
+            @core.Vec2::new(-ray.dir.x, -ray.dir.y),
+            @core.Vec2::new(1.0F, 0.0F),
+          )
+          return Some(RayIntersection::{ toi: 0.0F, normal })
+        }
+        // Treat the ray as starting inside the rounded region; find the first exit.
+        start_dist = r - 1.0e-12F
+      }
+      let steps = 64
+      let step = if max_dist <= 0.0F {
+        0.0F
+      } else {
+        max_dist / Float::from_int(steps)
+      }
+      let mut prev_t = 0.0F
+      let mut prev_f = start_dist - r
+      let mut bracket : (@core.Real, @core.Real)? = None
+      for i in 1..<(steps + 1) {
+        let t = Float::from_int(i) * step
+        let p = ray_point(ray, t)
+        let f = dist_to_inner(base, center, rotation, p) - r
+        if prev_f > 0.0F {
+          if f <= 0.0F {
+            bracket = Some((prev_t, t))
+            break
+          }
+        } else if f >= 0.0F {
+          bracket = Some((prev_t, t))
+          break
+        }
+        prev_t = t
+        prev_f = f
+      }
+      if bracket is None {
+        return None
+      }
+      let (lo0, hi0) = bracket.unwrap()
+      let mut lo = lo0
+      let mut hi = hi0
+      for _ in 0..<60 {
+        let mid = 0.5F * (lo + hi)
+        let p = ray_point(ray, mid)
+        let f = dist_to_inner(base, center, rotation, p) - r
+        if prev_f > 0.0F {
+          if f <= 0.0F {
+            hi = mid
+          } else {
+            lo = mid
+          }
+        } else if f >= 0.0F {
+          hi = mid
+        } else {
+          lo = mid
+        }
+      }
+      let toi = hi
+      if toi < 0.0F || toi > max_dist {
+        return None
+      }
+      let hit_point = ray_point(ray, toi)
+      let proj = project_point_on_shape(
+        center, rotation, base, hit_point, false,
+      )
+      let delta = hit_point.sub(proj.point)
+      let normal = if delta.length_squared() > 1.0e-12F {
+        delta.normalize()
+      } else {
+        normalize_or_fallback(
+          @core.Vec2::new(-ray.dir.x, -ray.dir.y),
+          @core.Vec2::new(1.0F, 0.0F),
+        )
+      }
+      Some(RayIntersection::{ toi, normal })
+    }
     Shape::Ball(radius) =>
       ray_intersect_ball_and_get_normal(ray, center, radius, max_dist, solid)
     Shape::Cuboid(hw, hh) =>
@@ -3708,6 +3693,40 @@ fn project_point_on_shape(
   solid : Bool,
 ) -> PointProjection {
   match shape {
+    Shape::Round(inner, radius) => {
+      let base = inner.val
+      let r = if radius < 0.0F { 0.0F } else { radius }
+      if r <= 0.0F {
+        project_point_on_shape(center, rotation, base, point, solid)
+      } else {
+        let inner_solid = project_point_on_shape(
+          center, rotation, base, point, true,
+        )
+        let inside_inner = inner_solid.is_inside
+        let inner_boundary = project_point_on_shape(
+          center, rotation, base, point, false,
+        )
+        let delta = point.sub(inner_boundary.point)
+        let dist = delta.length()
+        let inside_round = inside_inner || dist <= r
+        if solid && inside_round {
+          PointProjection::{ point, is_inside: true }
+        } else {
+          let mut dir = if inside_inner {
+            @core.Vec2::new(-delta.x, -delta.y)
+          } else {
+            delta
+          }
+          if dir.length_squared() <= 1.0e-12F {
+            dir = @core.Vec2::new(1.0F, 0.0F)
+          }
+          let boundary = inner_boundary.point.add(
+            vec2_scale(dir.normalize(), r),
+          )
+          PointProjection::{ point: boundary, is_inside: inside_round }
+        }
+      }
+    }
     Shape::Ball(radius) => project_point_on_ball(center, radius, point, solid)
     Shape::Cuboid(hw, hh) =>
       project_point_on_cuboid_oriented(center, rotation, hw, hh, point, solid)
@@ -3834,6 +3853,45 @@ fn project_point_on_shape_and_get_feature(
   }
 
   match shape {
+    Shape::Round(inner, radius) => {
+      let base = inner.val
+      let r = if radius < 0.0F { 0.0F } else { radius }
+      if r <= 0.0F {
+        project_point_on_shape_and_get_feature(
+          center, rotation, base, point, solid,
+        )
+      } else {
+        let (inner_solid, fid_solid) = project_point_on_shape_and_get_feature(
+          center, rotation, base, point, true,
+        )
+        let inside_inner = inner_solid.is_inside
+        let (inner_boundary, fid_boundary) = project_point_on_shape_and_get_feature(
+          center, rotation, base, point, false,
+        )
+        let delta = point.sub(inner_boundary.point)
+        let dist = delta.length()
+        let inside_round = inside_inner || dist <= r
+        if solid && inside_round {
+          (PointProjection::{ point, is_inside: true }, fid_solid)
+        } else {
+          let mut dir = if inside_inner {
+            @core.Vec2::new(-delta.x, -delta.y)
+          } else {
+            delta
+          }
+          if dir.length_squared() <= 1.0e-12F {
+            dir = @core.Vec2::new(1.0F, 0.0F)
+          }
+          let boundary = inner_boundary.point.add(
+            vec2_scale(dir.normalize(), r),
+          )
+          (
+            PointProjection::{ point: boundary, is_inside: inside_round },
+            fid_boundary,
+          )
+        }
+      }
+    }
     Shape::Ball(radius) =>
       project_point_on_ball_and_get_feature(center, radius, point, solid)
     Shape::Cuboid(hw, hh) =>

--- a/collision/rounded_shapes_test.mbt
+++ b/collision/rounded_shapes_test.mbt
@@ -1,0 +1,92 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "round_* builders create rounded geometry (not contact_skin)" {
+  let collider = ColliderBuilder::round_cuboid(1.0F, 1.0F, 0.2F).build()
+  inspect(collider.contact_skin() == 0.0F, content="true")
+  match collider.shape() {
+    Shape::Round(_, r) => inspect(@core.abs(r - 0.2F) < 1.0e-6F, content="true")
+    _ => inspect(false, content="true")
+  }
+}
+
+///|
+test "rounded shapes affect query projections and rays" {
+  fn collider_is_round(colliders : ColliderSet, id : Int) -> Bool {
+    if id < 0 || id >= colliders.colliders.length() {
+      return false
+    }
+    match colliders.colliders[id] {
+      Some(co) =>
+        match co.shape() {
+          Shape::Round(_, _) => true
+          _ => false
+        }
+      None => false
+    }
+  }
+
+  fn project_left_x(
+    bodies : @dynamics.RigidBodySet,
+    colliders : ColliderSet,
+  ) -> @core.Real {
+    let pipeline = QueryPipeline::new(QueryFilter::new(), bodies, colliders)
+    let point = @core.Vec2::new(-3.0F, 0.0F)
+    match pipeline.project_point(bodies, colliders, point, 0.0F, false) {
+      Some(hit) => hit.1.point().x
+      None => 1.0e30F
+    }
+  }
+
+  fn cast_left_hit_toi(
+    bodies : @dynamics.RigidBodySet,
+    colliders : ColliderSet,
+    max_toi : @core.Real,
+  ) -> @core.Real {
+    let pipeline = QueryPipeline::new(QueryFilter::new(), bodies, colliders)
+    let ray = Ray::new(
+      @core.Vec2::new(-3.0F, 0.0F),
+      @core.Vec2::new(1.0F, 0.0F),
+    )
+    match pipeline.cast_ray(bodies, colliders, ray, max_toi, true) {
+      Some(hit) => hit.1
+      None => -1.0F
+    }
+  }
+
+  let bodies0 = @dynamics.RigidBodySet::new()
+  let colliders_round0 = ColliderSet::new()
+  colliders_round0.insert(
+    ColliderBuilder::round_cuboid(1.0F, 1.0F, 0.2F).build(),
+  )
+  |> ignore
+  inspect(collider_is_round(colliders_round0, 0), content="true")
+  let proj_round = project_left_x(bodies0, colliders_round0)
+  inspect(colliders_round0.colliders[0] is Some(_), content="true")
+  inspect(collider_is_round(colliders_round0, 0), content="true")
+  inspect(@core.abs(proj_round - -1.2F) < 1.0e-3F, content="true")
+  let toi_round_short = cast_left_hit_toi(bodies0, colliders_round0, 1.9F)
+  inspect(toi_round_short >= 0.0F, content="true")
+  let bodies1 = @dynamics.RigidBodySet::new()
+  let colliders_skin1 = ColliderSet::new()
+  colliders_skin1.insert(
+    ColliderBuilder::cuboid(1.0F, 1.0F).contact_skin(0.2F).build(),
+  )
+  |> ignore
+  let proj_skin = project_left_x(bodies1, colliders_skin1)
+  inspect(@core.abs(proj_skin - -1.0F) < 1.0e-3F, content="true")
+  let toi_skin_short = cast_left_hit_toi(bodies1, colliders_skin1, 1.9F)
+  inspect(toi_skin_short < 0.0F, content="true")
+}

--- a/control/character_controller.mbt
+++ b/control/character_controller.mbt
@@ -378,6 +378,10 @@ fn try_normalize_and_get_length(
 ///|
 fn compute_extents(shape : @collision.Shape) -> (@core.Real, @core.Real) {
   match shape {
+    @collision.Shape::Round(inner, radius) => {
+      let (hw, hh) = compute_extents(inner.val)
+      (hw + radius, hh + radius)
+    }
     @collision.Shape::Ball(r) => (r, r)
     @collision.Shape::Cuboid(hw, hh) => (hw, hh)
     @collision.Shape::CapsuleX(half_height, radius) =>

--- a/pipeline/ccd.mbt
+++ b/pipeline/ccd.mbt
@@ -15,6 +15,8 @@
 ///|
 fn shape_ccd_thickness(shape : @collision.Shape) -> @core.Real {
   match shape {
+    @collision.Shape::Round(inner, radius) =>
+      shape_ccd_thickness(inner.val) + radius
     @collision.Shape::Ball(radius) => radius
     @collision.Shape::Cuboid(hw, hh) => if hw < hh { hw } else { hh }
     @collision.Shape::CapsuleX(_, radius) => radius
@@ -46,6 +48,8 @@ fn shape_ccd_thickness(shape : @collision.Shape) -> @core.Real {
 ///|
 fn shape_bounding_radius(shape : @collision.Shape) -> @core.Real {
   match shape {
+    @collision.Shape::Round(inner, radius) =>
+      shape_bounding_radius(inner.val) + radius
     @collision.Shape::Ball(radius) => radius
     @collision.Shape::Cuboid(hw, hh) => Float::sqrt(hw * hw + hh * hh)
     @collision.Shape::CapsuleX(half_height, radius)


### PR DESCRIPTION
Fixes #13.

- Implement true rounded shapes as Shape::Round (queries + contacts).
- Ensure QueryPipeline BVH build does not mutate collider shapes.
- Add regression tests for rounded-shape ray/projection behavior.

Tests: moon test --frozen