### PR TITLE
Fix 2D HeightField collider primitive

### DIFF
--- a/collision/broad_phase_bvh_test.mbt
+++ b/collision/broad_phase_bvh_test.mbt
@@ -251,6 +251,47 @@ fn compute_aabb_for_test(
           @core.Vec2::new(max_x + pd, max_y + pd),
         )
       }
+    Shape::HeightField(heights, scale) => {
+      let vertices : Array[@core.Vec2] = []
+      if heights.length() == 0 {
+        return (center, center)
+      }
+      if heights.length() == 1 {
+        vertices.push(@core.Vec2::new(0.0F, heights[0] * scale.y))
+      } else {
+        let denom = Float::from_double((heights.length() - 1).to_double())
+        let step = scale.x / denom
+        for i in 0..<heights.length() {
+          let x = -scale.x / 2.0F + Float::from_double(i.to_double()) * step
+          let y = heights[i] * scale.y
+          vertices.push(@core.Vec2::new(x, y))
+        }
+      }
+      let rot = @core.Rot2::from_angle(rotation)
+      let mut min_x = 1.0e30F
+      let mut max_x = -1.0e30F
+      let mut min_y = 1.0e30F
+      let mut max_y = -1.0e30F
+      for i in 0..<vertices.length() {
+        let wp = center.add(rot.rotate_vec2(vertices[i]))
+        if wp.x < min_x {
+          min_x = wp.x
+        }
+        if wp.x > max_x {
+          max_x = wp.x
+        }
+        if wp.y < min_y {
+          min_y = wp.y
+        }
+        if wp.y > max_y {
+          max_y = wp.y
+        }
+      }
+      (
+        @core.Vec2::new(min_x - pd, min_y - pd),
+        @core.Vec2::new(max_x + pd, max_y + pd),
+      )
+    }
     Shape::ConvexPolygon(vertices) =>
       if vertices.length() == 0 {
         (center, center)

--- a/collision/collider_set.mbt
+++ b/collision/collider_set.mbt
@@ -437,6 +437,7 @@ pub(all) enum Shape {
   CapsuleY(@core.Real, @core.Real)
   Segment(@core.Vec2, @core.Vec2)
   Polyline(Array[@core.Vec2], Array[(Int, Int)]?)
+  HeightField(Array[@core.Real], @core.Vec2)
   ConvexPolygon(Array[@core.Vec2])
   TriMesh(Array[@core.Vec2], Array[(Int, Int, Int)])
   Compound(Array[(@core.Isometry2, Shape)])
@@ -933,23 +934,34 @@ pub fn ColliderBuilder::heightfield(
   heights : Array[@core.Real],
   scale : @core.Vec2,
 ) -> ColliderBuilder {
-  if heights.length() == 0 {
-    // Degenerate heightfield: empty polyline.
-    return ColliderBuilder::polyline([], None)
+  let hs : Array[@core.Real] = []
+  for i in 0..<heights.length() {
+    hs.push(heights[i])
   }
+  ColliderBuilder::new(Shape::HeightField(hs, scale))
+}
+
+///|
+fn heightfield_vertices(
+  heights : Array[@core.Real],
+  scale : @core.Vec2,
+) -> Array[@core.Vec2] {
   let vertices : Array[@core.Vec2] = []
+  if heights.length() == 0 {
+    return vertices
+  }
   if heights.length() == 1 {
     vertices.push(@core.Vec2::new(0.0F, heights[0] * scale.y))
-  } else {
-    let denom = Float::from_double((heights.length() - 1).to_double())
-    let step = scale.x / denom
-    for i in 0..<heights.length() {
-      let x = -scale.x / 2.0F + Float::from_double(i.to_double()) * step
-      let y = heights[i] * scale.y
-      vertices.push(@core.Vec2::new(x, y))
-    }
+    return vertices
   }
-  ColliderBuilder::polyline(vertices, None)
+  let denom = Float::from_double((heights.length() - 1).to_double())
+  let step = scale.x / denom
+  for i in 0..<heights.length() {
+    let x = -scale.x / 2.0F + Float::from_double(i.to_double()) * step
+    let y = heights[i] * scale.y
+    vertices.push(@core.Vec2::new(x, y))
+  }
+  vertices
 }
 
 ///|
@@ -1806,6 +1818,8 @@ fn shape_mass_properties(
     }
     Shape::Polyline(_, _) =>
       @core.MassProperties::new(0.0F, 0.0F, @core.Vec2::zero())
+    Shape::HeightField(_, _) =>
+      @core.MassProperties::new(0.0F, 0.0F, @core.Vec2::zero())
     Shape::ConvexPolygon(vertices) => {
       if vertices.length() < 3 {
         return @core.MassProperties::new(0.0F, 0.0F, @core.Vec2::zero())
@@ -2345,6 +2359,15 @@ fn write_points(sb : StringBuilder, points : Array[@core.Vec2]) -> Unit {
 }
 
 ///|
+fn write_reals(sb : StringBuilder, values : Array[@core.Real]) -> Unit {
+  sb.write_object(values.length())
+  for i in 0..<values.length() {
+    sb.write_char(';')
+    sb.write_object(values[i])
+  }
+}
+
+///|
 fn write_pairs(sb : StringBuilder, pairs : Array[(Int, Int)]) -> Unit {
   sb.write_object(pairs.length())
   for i in 0..<pairs.length() {
@@ -2429,6 +2452,13 @@ fn write_shape(sb : StringBuilder, shape : Shape) -> Unit {
       }
       sb.write_char(')')
     }
+    Shape::HeightField(heights, scale) => {
+      sb.write_string("hf(")
+      write_reals(sb, heights)
+      sb.write_char('|')
+      write_vec2(sb, scale)
+      sb.write_char(')')
+    }
     Shape::ConvexPolygon(points) => {
       sb.write_string("v(")
       write_points(sb, points)
@@ -2491,6 +2521,18 @@ fn parse_points(text : String) -> Array[@core.Vec2] {
     }
   }
   points
+}
+
+///|
+fn parse_reals(text : String) -> Array[@core.Real] {
+  let parts = split_values(text, ";")
+  let values : Array[@core.Real] = []
+  if parts.length() > 1 {
+    for i in 1..<parts.length() {
+      values.push(parse_real_value(parts[i]))
+    }
+  }
+  values
 }
 
 ///|
@@ -2588,6 +2630,16 @@ fn parse_shape(text : String) -> Shape {
       None
     }
     Shape::Polyline(points, indices)
+  } else if text.strip_prefix("hf("[:]) is Some(v) &&
+    v.strip_suffix(")"[:]) is Some(inner) {
+    let parts = split_values(inner.to_string(), "|")
+    let heights = if parts.length() > 0 { parse_reals(parts[0]) } else { [] }
+    let scale = if parts.length() > 1 {
+      parse_vec2(parts[1])
+    } else {
+      @core.Vec2::new(1.0F, 1.0F)
+    }
+    Shape::HeightField(heights, scale)
   } else if text.strip_prefix("v("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
     Shape::ConvexPolygon(parse_points(inner.to_string()))
@@ -3689,6 +3741,16 @@ fn shapes_intersect(
     }
     _ => ()
   }
+  let shape1 = match shape1 {
+    Shape::HeightField(heights, scale) =>
+      Shape::Polyline(heightfield_vertices(heights, scale), None)
+    _ => shape1
+  }
+  let shape2 = match shape2 {
+    Shape::HeightField(heights, scale) =>
+      Shape::Polyline(heightfield_vertices(heights, scale), None)
+    _ => shape2
+  }
   fn cross2(a : @core.Vec2, b : @core.Vec2) -> @core.Real {
     a.x * b.y - a.y * b.x
   }
@@ -4257,6 +4319,15 @@ fn shapes_intersect(
           false
         }
       }
+      Shape::HeightField(heights, scale) =>
+        halfspace_intersects_shape_basic(
+          hs_pos,
+          hs_rot,
+          outward_normal_local,
+          Shape::Polyline(heightfield_vertices(heights, scale), None),
+          other_pos,
+          other_rot,
+        )
       Shape::ConvexPolygon(vertices) => {
         let vs = convex_polygon_world_vertices(other_pos, other_rot, vertices)
         for i in 0..<vs.length() {
@@ -6741,12 +6812,22 @@ fn build_contact_pair(
 
     let (shape1, radius1) = unwrap_round_shape(c1.shape)
     let (shape2, radius2) = unwrap_round_shape(c2.shape)
+    let shape1_norm = match shape1 {
+      Shape::HeightField(heights, scale) =>
+        Shape::Polyline(heightfield_vertices(heights, scale), None)
+      _ => shape1
+    }
+    let shape2_norm = match shape2 {
+      Shape::HeightField(heights, scale) =>
+        Shape::Polyline(heightfield_vertices(heights, scale), None)
+      _ => shape2
+    }
     let c1_base = c1
-    c1_base.shape = shape1
+    c1_base.shape = shape1_norm
     let c2_base = c2
-    c2_base.shape = shape2
+    c2_base.shape = shape2_norm
     let out : Array[ContactManifold] = []
-    match (shape1, shape2) {
+    match (shape1_norm, shape2_norm) {
       (Shape::HalfSpace(n), Shape::Ball(r)) =>
         if halfspace_ball_manifold(prediction_distance, c1_base, n, c2_base, r)
           is Some(m) {
@@ -7872,6 +7953,13 @@ fn compute_shape_aabb(
           max: @core.Vec2::new(max_x + pd, max_y + pd),
         }
       }
+    Shape::HeightField(heights, scale) =>
+      compute_shape_aabb(
+        Shape::Polyline(heightfield_vertices(heights, scale), None),
+        center,
+        rotation,
+        pd,
+      )
     Shape::ConvexPolygon(vertices) =>
       if vertices.length() == 0 {
         Aabb::{ min: center, max: center }

--- a/collision/heightfield_2d_test.mbt
+++ b/collision/heightfield_2d_test.mbt
@@ -1,0 +1,83 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Regression test for Issue #15: heightfield must be a true primitive, not a polyline alias.
+test "heightfield builder produces Shape::HeightField" {
+  let heights = [0.0F, 1.0F, 0.0F]
+  let scale = @core.Vec2::new(10.0F, 2.0F)
+  let collider = ColliderBuilder::heightfield(heights, scale).build()
+  match collider.shape() {
+    Shape::HeightField(hs, sc) => {
+      inspect(hs.length() == heights.length(), content="true")
+      inspect(@core.abs(sc.x - 10.0F) < 1.0e-6F, content="true")
+      inspect(@core.abs(sc.y - 2.0F) < 1.0e-6F, content="true")
+    }
+    _ => inspect(false, content="true")
+  }
+}
+
+///|
+test "heightfield participates in contacts and ray queries" {
+  let bodies = @dynamics.RigidBodySet::new()
+  let colliders = ColliderSet::new()
+  let narrow_phase = NarrowPhase::new()
+  let impulse_joints = @dynamics.ImpulseJointSet::new()
+  let multibody_joints = @dynamics.MultibodyJointSet::new()
+  let ground_body = bodies.insert(@dynamics.RigidBodyBuilder::fixed().build())
+  let ground = colliders.insert_with_parent(
+    ColliderBuilder::heightfield([0.0F, 0.0F], @core.Vec2::new(10.0F, 1.0F)).build(),
+    ground_body,
+    bodies,
+  )
+  let ball_body = bodies.insert(
+    @dynamics.RigidBodyBuilder::dynamic()
+    .translation(@core.Vec2::new(0.0F, 0.5F))
+    .build(),
+  )
+  let ball = colliders.insert_with_parent(
+    ColliderBuilder::ball(1.0F).build(),
+    ball_body,
+    bodies,
+  )
+  narrow_phase.update_with_pairs(
+    bodies,
+    colliders,
+    0.0F,
+    [(ground, ball)],
+    impulse_joints,
+    multibody_joints,
+  )
+  if narrow_phase.contact_pair(ground, ball) is Some(pair) {
+    inspect(pair.manifold_count() > 0, content="true")
+  } else {
+    inspect(false, content="true")
+  }
+  let query_pipeline = BroadPhaseBvh::new().as_query_pipeline(
+    bodies,
+    colliders,
+    QueryFilter::new(),
+  )
+  // Cast far enough from the ball so the first hit is the terrain.
+  let ray = Ray::new(@core.Vec2::new(4.0F, 10.0F), @core.Vec2::new(0.0F, -1.0F))
+  if query_pipeline.cast_ray_and_get_normal(
+      bodies, colliders, ray, 100.0F, true,
+    )
+    is Some(hit) {
+    inspect(ColliderHandle::equals(hit.0, ground), content="true")
+    inspect(@core.abs(hit.1.toi() - 10.0F) < 1.0e-4F, content="true")
+  } else {
+    inspect(false, content="true")
+  }
+}

--- a/collision/pkg.generated.mbti
+++ b/collision/pkg.generated.mbti
@@ -1079,6 +1079,7 @@ pub(all) enum Shape {
   CapsuleY(Float, Float)
   Segment(@core.Vec2, @core.Vec2)
   Polyline(Array[@core.Vec2], Array[(Int, Int)]?)
+  HeightField(Array[Float], @core.Vec2)
   ConvexPolygon(Array[@core.Vec2])
   TriMesh(Array[@core.Vec2], Array[(Int, Int, Int)])
   Compound(Array[(@core.Isometry2, Shape)])

--- a/collision/query_pipeline.mbt
+++ b/collision/query_pipeline.mbt
@@ -1818,6 +1818,7 @@ pub fn QueryPipeline::cast_shape(
     Shape::Round(inner, r) => Shape::Round(inner, r + target_distance)
     Shape::Segment(_, _) => shape
     Shape::Polyline(_, _) => shape
+    Shape::HeightField(_, _) => shape
     Shape::ConvexPolygon(_) => shape
     Shape::TriMesh(_, _) => shape
     Shape::Compound(_) => shape
@@ -1908,6 +1909,7 @@ pub fn QueryPipeline::cast_shape(
             }
           }
           Shape::HalfSpace(_) => None
+          Shape::HeightField(_, _) => None
           Shape::Segment(a, b) => {
             let (sa, sb) = segment_world_endpoints(
               target_center, target_rotation, a, b,
@@ -2261,6 +2263,10 @@ pub fn QueryPipeline::cast_shape_nonlinear(
         }
         best
       }
+      Shape::HeightField(heights, scale) =>
+        shape_bounding_radius(
+          Shape::Polyline(heightfield_vertices(heights, scale), None),
+        )
       Shape::ConvexPolygon(vertices) => {
         let mut best = 0.0F
         for i in 0..<vertices.length() {
@@ -2336,6 +2342,14 @@ pub fn QueryPipeline::cast_shape_nonlinear(
           center,
           rotation,
           Shape::HalfSpace(n),
+          point,
+          false,
+        ).point
+      Shape::HeightField(heights, scale) =>
+        project_point_on_shape(
+          center,
+          rotation,
+          Shape::Polyline(heightfield_vertices(heights, scale), None),
           point,
           false,
         ).point
@@ -2712,6 +2726,13 @@ fn point_in_shape(
       let delta = point.sub(proj.point)
       delta.dot(delta) <= 1.0e-12F
     }
+    Shape::HeightField(heights, scale) =>
+      point_in_shape(
+        Shape::Polyline(heightfield_vertices(heights, scale), None),
+        center,
+        rotation,
+        point,
+      )
     Shape::ConvexPolygon(vertices) => {
       let rot = @core.Rot2::from_angle(rotation)
       let inv = rot.inverse()
@@ -2882,6 +2903,11 @@ fn compute_query_shape_aabb(
           @core.Vec2::new(max_x, max_y),
         )
       }
+    Shape::HeightField(heights, scale) =>
+      compute_query_shape_aabb(
+        shape_pos,
+        Shape::Polyline(heightfield_vertices(heights, scale), None),
+      )
     Shape::ConvexPolygon(vertices) =>
       if vertices.length() == 0 {
         @core.Aabb::new(center, center)
@@ -3705,6 +3731,16 @@ fn ray_intersect_shape_and_get_normal(
       ray_intersect_polyline_and_get_normal(
         ray, center, rotation, vertices, indices, max_dist, solid,
       )
+    Shape::HeightField(heights, scale) =>
+      ray_intersect_polyline_and_get_normal(
+        ray,
+        center,
+        rotation,
+        heightfield_vertices(heights, scale),
+        None,
+        max_dist,
+        solid,
+      )
     Shape::ConvexPolygon(vertices) =>
       ray_intersect_convex_polygon_oriented_and_get_normal(
         ray, center, rotation, vertices, max_dist, solid,
@@ -3865,6 +3901,14 @@ fn project_point_on_shape(
       project_point_on_segment(center, rotation, a, b, point)
     Shape::Polyline(vertices, indices) =>
       project_point_on_polyline(center, rotation, vertices, indices, point)
+    Shape::HeightField(heights, scale) =>
+      project_point_on_polyline(
+        center,
+        rotation,
+        heightfield_vertices(heights, scale),
+        None,
+        point,
+      )
     Shape::ConvexPolygon(vertices) =>
       project_point_on_convex_polygon_oriented(
         center, rotation, vertices, point, solid,
@@ -4051,6 +4095,14 @@ fn project_point_on_shape_and_get_feature(
     Shape::Polyline(vertices, indices) =>
       project_point_on_polyline_and_get_feature(
         center, rotation, vertices, indices, point,
+      )
+    Shape::HeightField(heights, scale) =>
+      project_point_on_polyline_and_get_feature(
+        center,
+        rotation,
+        heightfield_vertices(heights, scale),
+        None,
+        point,
       )
     Shape::ConvexPolygon(vertices) =>
       project_point_on_convex_polygon_oriented_and_get_feature(

--- a/control/character_controller.mbt
+++ b/control/character_controller.mbt
@@ -410,6 +410,17 @@ fn compute_extents(shape : @collision.Shape) -> (@core.Real, @core.Real) {
       }
       (hw, hh)
     }
+    @collision.Shape::HeightField(heights, scale) => {
+      let hw = @core.abs(scale.x) * 0.5F
+      let mut hh = 0.0F
+      for i in 0..<heights.length() {
+        let ay = @core.abs(heights[i] * scale.y)
+        if ay > hh {
+          hh = ay
+        }
+      }
+      (hw, hh)
+    }
     @collision.Shape::ConvexPolygon(vertices) => {
       let mut hw = 0.0F
       let mut hh = 0.0F

--- a/pipeline/ccd.mbt
+++ b/pipeline/ccd.mbt
@@ -24,6 +24,7 @@ fn shape_ccd_thickness(shape : @collision.Shape) -> @core.Real {
     @collision.Shape::CapsuleY(_, radius) => radius
     @collision.Shape::Segment(_, _) => 0.0F
     @collision.Shape::Polyline(_, _) => 0.0F
+    @collision.Shape::HeightField(_, _) => 0.0F
     @collision.Shape::ConvexPolygon(_) => 0.0F
     @collision.Shape::TriMesh(_, _) => 0.0F
     @collision.Shape::Compound(parts) => {
@@ -74,6 +75,16 @@ fn shape_bounding_radius(shape : @collision.Shape) -> @core.Real {
         }
       }
       best
+    }
+    @collision.Shape::HeightField(heights, scale) => {
+      let mut max_abs_y = 0.0F
+      for i in 0..<heights.length() {
+        let ay = @core.abs(heights[i] * scale.y)
+        if ay > max_abs_y {
+          max_abs_y = ay
+        }
+      }
+      Float::sqrt(0.5F * scale.x * (0.5F * scale.x) + max_abs_y * max_abs_y)
     }
     @collision.Shape::ConvexPolygon(vertices) => {
       let mut best = 0.0F


### PR DESCRIPTION
Closes #15.

- ColliderBuilder::heightfield now produces Shape::HeightField (instead of polyline alias).
- QueryPipeline/contact generation treat HeightField as a true heightfield segment set.
- Add regression tests for shape kind + contacts + ray queries.

Tests: moon test --frozen