### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/collision/broad_phase3d.mbt
+++ b/collision/broad_phase3d.mbt
@@ -16,11 +16,14 @@
 pub struct ColliderPair3D {
   collider1 : ColliderHandle3D
   collider2 : ColliderHandle3D
+}
 
-  fn new(
-    collider1 : ColliderHandle3D,
-    collider2 : ColliderHandle3D,
-  ) -> ColliderPair3D
+///|
+pub fn ColliderPair3D::ColliderPair3D(
+  collider1 : ColliderHandle3D,
+  collider2 : ColliderHandle3D,
+) -> ColliderPair3D {
+  ColliderPair3D::new(collider1, collider2)
 }
 
 ///|
@@ -52,8 +55,11 @@ pub struct BroadPhase3D {
   pairs : Array[(ColliderHandle3D, ColliderHandle3D)]
   prev_pairs : Array[(ColliderHandle3D, ColliderHandle3D)]
   events : Array[BroadPhasePairEvent3D]
+}
 
-  fn new() -> BroadPhase3D
+///|
+pub fn BroadPhase3D::BroadPhase3D() -> BroadPhase3D {
+  BroadPhase3D::new()
 }
 
 ///|

--- a/collision/collider3.mbt
+++ b/collision/collider3.mbt
@@ -86,8 +86,11 @@ fn ColliderSet3::sync_with_bodies(
 /// 3D-flavored collider set (dim3,f32).
 pub struct ColliderSet3 {
   inner : ColliderSet
+}
 
-  fn new() -> ColliderSet3
+///|
+pub fn ColliderSet3::ColliderSet3() -> ColliderSet3 {
+  ColliderSet3::new()
 }
 
 ///|

--- a/collision/collider3d.mbt
+++ b/collision/collider3d.mbt
@@ -1083,7 +1083,7 @@ pub fn ColliderBuilder3D::round_convex_decomposition(
       continue
     }
     let end = if start + chunk < tri_count { start + chunk } else { tri_count }
-    let used : @hashset.HashSet[Int] = @hashset.new(capacity=chunk * 3)
+    let used : @hashset.HashSet[Int] = @hashset.HashSet([], capacity=chunk * 3)
     for ii in start..<end {
       let tid = tri_ids[ii]
       let (i0, i1, i2) = tris[tid]
@@ -1132,7 +1132,8 @@ pub fn ColliderBuilder3D::voxels_from_points(
     }
   }
 
-  let occupied : @hashset.HashSet[(Int, Int, Int)] = @hashset.new(
+  let occupied : @hashset.HashSet[(Int, Int, Int)] = @hashset.HashSet(
+    [],
     capacity=points.length(),
   )
   for i in 0..<points.length() {
@@ -1226,13 +1227,15 @@ pub fn ColliderBuilder3D::voxels_from_points(
       max_key = (max_key.0, max_key.1, iz)
     }
   }
-  let key_to_id : @hashmap.HashMap[(Int, Int, Int), Int] = @hashmap.new(
+  let key_to_id : @hashmap.HashMap[(Int, Int, Int), Int] = @hashmap.HashMap(
+    [],
     capacity=voxels.length(),
   )
   for i in 0..<voxels.length() {
     key_to_id.set(voxels[i], i)
   }
-  let columns : @hashmap.HashMap[(Int, Int), Array[Int]] = @hashmap.new(
+  let columns : @hashmap.HashMap[(Int, Int), Array[Int]] = @hashmap.HashMap(
+    [],
     capacity=voxels.length(),
   )
   fn push_sorted_unique(ys : Array[Int], y : Int) -> Unit {

--- a/collision/collider_set.mbt
+++ b/collision/collider_set.mbt
@@ -2796,7 +2796,7 @@ pub fn ColliderSet::new() -> ColliderSet {
 fn split_values(text : String, sep : String) -> Array[String] {
   let values : Array[String] = []
   for part in text.split(sep[:]) {
-    let value = part.to_string()
+    let value = part.to_owned()
     if value.length() > 0 {
       values.push(value)
     }
@@ -3168,41 +3168,41 @@ fn parse_triples(text : String) -> Array[(Int, Int, Int)] {
 fn parse_shape(text : String) -> Shape {
   if text.strip_prefix("r("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    let parts = split_top_level(inner.to_string(), ',')
+    let parts = split_top_level(inner.to_owned(), ',')
     if parts.length() >= 2 {
       let base = parse_shape(parts[0])
       let radius = parse_real_value(parts[1])
       Shape::Round(Ref(base), radius)
     } else {
-      Shape::Round(Ref(parse_shape(inner.to_string())), 0.0F)
+      Shape::Round(Ref(parse_shape(inner.to_owned())), 0.0F)
     }
   } else if text.strip_prefix("b("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    Shape::Ball(parse_real_value(inner.to_string()))
+    Shape::Ball(parse_real_value(inner.to_owned()))
   } else if text.strip_prefix("c("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    let parts = split_values(inner.to_string(), ",")
+    let parts = split_values(inner.to_owned(), ",")
     let hw = if parts.length() > 0 { parse_real_value(parts[0]) } else { 0.0F }
     let hh = if parts.length() > 1 { parse_real_value(parts[1]) } else { 0.0F }
     Shape::Cuboid(hw, hh)
   } else if text.strip_prefix("h("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    Shape::HalfSpace(parse_vec2(inner.to_string()))
+    Shape::HalfSpace(parse_vec2(inner.to_owned()))
   } else if text.strip_prefix("x("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    let parts = split_values(inner.to_string(), ",")
+    let parts = split_values(inner.to_owned(), ",")
     let h = if parts.length() > 0 { parse_real_value(parts[0]) } else { 0.0F }
     let r = if parts.length() > 1 { parse_real_value(parts[1]) } else { 0.0F }
     Shape::CapsuleX(h, r)
   } else if text.strip_prefix("y("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    let parts = split_values(inner.to_string(), ",")
+    let parts = split_values(inner.to_owned(), ",")
     let h = if parts.length() > 0 { parse_real_value(parts[0]) } else { 0.0F }
     let r = if parts.length() > 1 { parse_real_value(parts[1]) } else { 0.0F }
     Shape::CapsuleY(h, r)
   } else if text.strip_prefix("s("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    let parts = split_values(inner.to_string(), ",")
+    let parts = split_values(inner.to_owned(), ",")
     let a = if parts.length() > 1 {
       @core.Vec2::new(parse_real_value(parts[0]), parse_real_value(parts[1]))
     } else {
@@ -3216,7 +3216,7 @@ fn parse_shape(text : String) -> Shape {
     Shape::Segment(a, b)
   } else if text.strip_prefix("p("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    let parts = split_values(inner.to_string(), "|")
+    let parts = split_values(inner.to_owned(), "|")
     let points = if parts.length() > 0 { parse_points(parts[0]) } else { [] }
     let indices : Array[(Int, Int)]? = if parts.length() > 1 {
       if parts[1] == "-" {
@@ -3230,7 +3230,7 @@ fn parse_shape(text : String) -> Shape {
     Shape::Polyline(points, indices)
   } else if text.strip_prefix("hf("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    let parts = split_values(inner.to_string(), "|")
+    let parts = split_values(inner.to_owned(), "|")
     let heights = if parts.length() > 0 { parse_reals(parts[0]) } else { [] }
     let scale = if parts.length() > 1 {
       parse_vec2(parts[1])
@@ -3240,16 +3240,16 @@ fn parse_shape(text : String) -> Shape {
     Shape::HeightField(heights, scale)
   } else if text.strip_prefix("v("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    Shape::ConvexPolygon(parse_points(inner.to_string()))
+    Shape::ConvexPolygon(parse_points(inner.to_owned()))
   } else if text.strip_prefix("t("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    let parts = split_values(inner.to_string(), "|")
+    let parts = split_values(inner.to_owned(), "|")
     let vertices = if parts.length() > 0 { parse_points(parts[0]) } else { [] }
     let indices = if parts.length() > 1 { parse_triples(parts[1]) } else { [] }
     Shape::TriMesh(vertices, indices)
   } else if text.strip_prefix("o("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {
-    let parts = split_top_level(inner.to_string(), ';')
+    let parts = split_top_level(inner.to_owned(), ';')
     let items : Array[(@core.Isometry2, Shape)] = []
     if parts.length() > 1 {
       for i in 1..<parts.length() {
@@ -3377,26 +3377,26 @@ pub fn ColliderSet::deserialize(data : String) -> ColliderSet {
   let colliders : Array[Collider?] = []
   let modified_colliders : Array[ColliderHandle] = []
   for part in data.split(";"[:]) {
-    let value = part.to_string()
+    let value = part.to_owned()
     if value.strip_prefix("len="[:]) is Some(raw_view) {
-      len = parse_int_value(raw_view.to_string())
+      len = parse_int_value(raw_view.to_owned())
     } else if value.strip_prefix("gens="[:]) is Some(raw_view) {
-      let items = split_values(raw_view.to_string(), ",")
+      let items = split_values(raw_view.to_owned(), ",")
       for item in items {
         generations.push(parse_int_value(item))
       }
     } else if value.strip_prefix("free="[:]) is Some(raw_view) {
-      let items = split_values(raw_view.to_string(), ",")
+      let items = split_values(raw_view.to_owned(), ",")
       for item in items {
         free_list.push(parse_int_value(item))
       }
     } else if value.strip_prefix("colliders="[:]) is Some(raw_view) {
-      let entries = split_values(raw_view.to_string(), "|")
+      let entries = split_values(raw_view.to_owned(), "|")
       for entry in entries {
         if entry == "N" {
           colliders.push(None)
         } else if entry.strip_prefix("C^"[:]) is Some(rest_view) {
-          let fields = split_values(rest_view.to_string(), "^")
+          let fields = split_values(rest_view.to_owned(), "^")
           let shape = if fields.length() > 0 {
             parse_shape(fields[0])
           } else {

--- a/collision/collider_set.mbt
+++ b/collision/collider_set.mbt
@@ -906,7 +906,7 @@ fn collider_builder_rounded(
   }
   collider_builder_rebuild_with_shape(
     builder,
-    Shape::Round(Ref::new(builder.shape), r),
+    Shape::Round(Ref(builder.shape), r),
   )
 }
 
@@ -3172,9 +3172,9 @@ fn parse_shape(text : String) -> Shape {
     if parts.length() >= 2 {
       let base = parse_shape(parts[0])
       let radius = parse_real_value(parts[1])
-      Shape::Round(Ref::new(base), radius)
+      Shape::Round(Ref(base), radius)
     } else {
-      Shape::Round(Ref::new(parse_shape(inner.to_string())), 0.0F)
+      Shape::Round(Ref(parse_shape(inner.to_string())), 0.0F)
     }
   } else if text.strip_prefix("b("[:]) is Some(v) &&
     v.strip_suffix(")"[:]) is Some(inner) {

--- a/collision/collider_set.mbt
+++ b/collision/collider_set.mbt
@@ -16,8 +16,6 @@
 pub struct ColliderHandle {
   id : Int
   generation : Int
-
-  fn new(id : Int, generation : Int) -> ColliderHandle
 }
 
 ///|
@@ -731,14 +729,19 @@ pub struct ColliderFlags {
   active_collision_types : ActiveCollisionTypes
   active_hooks : ActiveHooks
   active_events : ActiveEvents
+}
 
-  fn new(
-    collision_groups : @dynamics.InteractionGroups,
-    solver_groups : @dynamics.InteractionGroups,
-    active_collision_types : ActiveCollisionTypes,
-    active_hooks : ActiveHooks,
-    active_events : ActiveEvents,
-  ) -> ColliderFlags
+///|
+pub fn ColliderFlags::ColliderFlags(
+  collision_groups : @dynamics.InteractionGroups,
+  solver_groups : @dynamics.InteractionGroups,
+  active_collision_types : ActiveCollisionTypes,
+  active_hooks : ActiveHooks,
+  active_events : ActiveEvents,
+) -> ColliderFlags {
+  ColliderFlags::new(
+    collision_groups, solver_groups, active_collision_types, active_hooks, active_events,
+  )
 }
 
 ///|
@@ -762,11 +765,14 @@ pub fn ColliderFlags::new(
 pub struct ColliderParent {
   handle : @dynamics.RigidBodyHandle
   pos_wrt_parent : @core.Isometry2
+}
 
-  fn new(
-    handle : @dynamics.RigidBodyHandle,
-    pos_wrt_parent : @core.Isometry2,
-  ) -> ColliderParent
+///|
+pub fn ColliderParent::ColliderParent(
+  handle : @dynamics.RigidBodyHandle,
+  pos_wrt_parent : @core.Isometry2,
+) -> ColliderParent {
+  ColliderParent::new(handle, pos_wrt_parent)
 }
 
 ///|
@@ -780,8 +786,13 @@ pub fn ColliderParent::new(
 ///|
 pub struct ColliderPosition {
   position : @core.Isometry2
+}
 
-  fn new(position : @core.Isometry2) -> ColliderPosition
+///|
+pub fn ColliderPosition::ColliderPosition(
+  position : @core.Isometry2,
+) -> ColliderPosition {
+  ColliderPosition::new(position)
 }
 
 ///|
@@ -2760,8 +2771,11 @@ pub struct ColliderSet {
   free_list : Array[Int]
   modified_colliders : Array[ColliderHandle]
   mut removed_colliders : Array[ColliderHandle]
+}
 
-  fn new() -> ColliderSet
+///|
+pub fn ColliderSet::ColliderSet() -> ColliderSet {
+  ColliderSet::new()
 }
 
 ///|
@@ -4230,11 +4244,14 @@ pub fn ContactManifoldPoint::set_data(
 pub struct ContactManifold {
   normal : @core.Vec2
   points : Array[ContactManifoldPoint]
+}
 
-  fn new(
-    normal : @core.Vec2,
-    points : Array[ContactManifoldPoint],
-  ) -> ContactManifold
+///|
+pub fn ContactManifold::ContactManifold(
+  normal : @core.Vec2,
+  points : Array[ContactManifoldPoint],
+) -> ContactManifold {
+  ContactManifold::new(normal, points)
 }
 
 ///|
@@ -4266,8 +4283,11 @@ pub struct NarrowPhase {
   mut intersections : Array[IntersectionPair]
   mut contacts : Array[(ColliderHandle, ColliderHandle, ContactPair)]
   mut query_dispatcher : QueryDispatcher
+}
 
-  fn new() -> NarrowPhase
+///|
+pub fn NarrowPhase::NarrowPhase() -> NarrowPhase {
+  NarrowPhase::new()
 }
 
 ///|
@@ -8884,8 +8904,11 @@ pub struct BroadPhaseBvh {
   pairs : Array[(ColliderHandle, ColliderHandle)]
   mut events : Array[BroadPhasePairEvent]
   override_aabbs : Array[(ColliderHandle, @core.Aabb)]
+}
 
-  fn new() -> BroadPhaseBvh
+///|
+pub fn BroadPhaseBvh::BroadPhaseBvh() -> BroadPhaseBvh {
+  BroadPhaseBvh::new()
 }
 
 ///|

--- a/collision/collider_set3d.mbt
+++ b/collision/collider_set3d.mbt
@@ -16,8 +16,6 @@
 pub struct ColliderHandle3D {
   id : Int
   generation : Int
-
-  fn new(id : Int, generation : Int) -> ColliderHandle3D
 }
 
 ///|
@@ -56,8 +54,11 @@ pub struct ColliderSet3D {
   colliders : Array[Collider3D?]
   generations : Array[Int]
   free_list : Array[Int]
+}
 
-  fn new() -> ColliderSet3D
+///|
+pub fn ColliderSet3D::ColliderSet3D() -> ColliderSet3D {
+  ColliderSet3D::new()
 }
 
 ///|

--- a/collision/events.mbt
+++ b/collision/events.mbt
@@ -24,8 +24,6 @@ const ACTIVE_EVENTS_INTERSECTION_EVENTS : Int = 1 << 2
 ///|
 pub struct ActiveEvents {
   mut bits : Int
-
-  fn new(bits : Int) -> ActiveEvents
 }
 
 ///|
@@ -175,8 +173,6 @@ const COLLISION_EVENT_FLAG_REMOVED : Int = 1 << 1
 ///|
 pub struct CollisionEventFlags {
   mut bits : Int
-
-  fn new(bits : Int) -> CollisionEventFlags
 }
 
 ///|
@@ -273,12 +269,15 @@ pub struct IntersectionEvent {
   collider1 : ColliderHandle
   collider2 : ColliderHandle
   intersecting : Bool
+}
 
-  fn new(
-    collider1 : ColliderHandle,
-    collider2 : ColliderHandle,
-    intersecting : Bool,
-  ) -> IntersectionEvent
+///|
+pub fn IntersectionEvent::IntersectionEvent(
+  collider1 : ColliderHandle,
+  collider2 : ColliderHandle,
+  intersecting : Bool,
+) -> IntersectionEvent {
+  IntersectionEvent::new(collider1, collider2, intersecting)
 }
 
 ///|
@@ -313,15 +312,21 @@ pub struct ContactForceEvent {
   total_force_magnitude : @core.Real
   max_force_direction : @core.Vec2
   max_force_magnitude : @core.Real
+}
 
-  fn new(
-    collider1 : ColliderHandle,
-    collider2 : ColliderHandle,
-    total_force : @core.Vec2,
-    total_force_magnitude : @core.Real,
-    max_force_direction : @core.Vec2,
-    max_force_magnitude : @core.Real,
-  ) -> ContactForceEvent
+///|
+pub fn ContactForceEvent::ContactForceEvent(
+  collider1 : ColliderHandle,
+  collider2 : ColliderHandle,
+  total_force : @core.Vec2,
+  total_force_magnitude : @core.Real,
+  max_force_direction : @core.Vec2,
+  max_force_magnitude : @core.Real,
+) -> ContactForceEvent {
+  ContactForceEvent::new(
+    collider1, collider2, total_force, total_force_magnitude, max_force_direction,
+    max_force_magnitude,
+  )
 }
 
 ///|

--- a/collision/events3d.mbt
+++ b/collision/events3d.mbt
@@ -75,12 +75,15 @@ pub struct IntersectionEvent3D {
   collider1 : ColliderHandle3D
   collider2 : ColliderHandle3D
   intersecting : Bool
+}
 
-  fn new(
-    collider1 : ColliderHandle3D,
-    collider2 : ColliderHandle3D,
-    intersecting : Bool,
-  ) -> IntersectionEvent3D
+///|
+pub fn IntersectionEvent3D::IntersectionEvent3D(
+  collider1 : ColliderHandle3D,
+  collider2 : ColliderHandle3D,
+  intersecting : Bool,
+) -> IntersectionEvent3D {
+  IntersectionEvent3D::new(collider1, collider2, intersecting)
 }
 
 ///|
@@ -119,15 +122,21 @@ pub struct ContactForceEvent3D {
   total_force_magnitude : @core.Real
   max_force_direction : @core.Vec3
   max_force_magnitude : @core.Real
+}
 
-  fn new(
-    collider1 : ColliderHandle3D,
-    collider2 : ColliderHandle3D,
-    total_force : @core.Vec3,
-    total_force_magnitude : @core.Real,
-    max_force_direction : @core.Vec3,
-    max_force_magnitude : @core.Real,
-  ) -> ContactForceEvent3D
+///|
+pub fn ContactForceEvent3D::ContactForceEvent3D(
+  collider1 : ColliderHandle3D,
+  collider2 : ColliderHandle3D,
+  total_force : @core.Vec3,
+  total_force_magnitude : @core.Real,
+  max_force_direction : @core.Vec3,
+  max_force_magnitude : @core.Real,
+) -> ContactForceEvent3D {
+  ContactForceEvent3D::new(
+    collider1, collider2, total_force, total_force_magnitude, max_force_direction,
+    max_force_magnitude,
+  )
 }
 
 ///|

--- a/collision/geometry_public_api.mbt
+++ b/collision/geometry_public_api.mbt
@@ -329,7 +329,8 @@ pub fn MeshConverter::apply(
           }
         }
 
-        let counts : @hashmap.HashMap[(Int, Int), Int] = @hashmap.new(
+        let counts : @hashmap.HashMap[(Int, Int), Int] = @hashmap.HashMap(
+          [],
           capacity=indices.length() * 3,
         )
         let keys : Array[(Int, Int)] = []

--- a/collision/geometry_public_api.mbt
+++ b/collision/geometry_public_api.mbt
@@ -15,8 +15,11 @@
 ///|
 pub struct SharedShape {
   shape : Shape
+}
 
-  fn new(shape : Shape) -> SharedShape
+///|
+pub fn SharedShape::SharedShape(shape : Shape) -> SharedShape {
+  SharedShape::new(shape)
 }
 
 ///|
@@ -106,8 +109,15 @@ pub struct Triangle {
   a : @core.Vec2
   b : @core.Vec2
   c : @core.Vec2
+}
 
-  fn new(a : @core.Vec2, b : @core.Vec2, c : @core.Vec2) -> Triangle
+///|
+pub fn Triangle::Triangle(
+  a : @core.Vec2,
+  b : @core.Vec2,
+  c : @core.Vec2,
+) -> Triangle {
+  Triangle::new(a, b, c)
 }
 
 ///|
@@ -129,8 +139,14 @@ pub fn Triangle::as_shape(self : Triangle) -> Shape {
 pub struct HeightField {
   heights : Array[@core.Real]
   scale : @core.Vec2
+}
 
-  fn new(heights : Array[@core.Real], scale : @core.Vec2) -> HeightField
+///|
+pub fn HeightField::HeightField(
+  heights : Array[@core.Real],
+  scale : @core.Vec2,
+) -> HeightField {
+  HeightField::new(heights, scale)
 }
 
 ///|
@@ -374,8 +390,14 @@ pub fn MeshConverter::convert(
 pub struct ColliderPair {
   collider1 : ColliderHandle
   collider2 : ColliderHandle
+}
 
-  fn new(a : ColliderHandle, b : ColliderHandle) -> ColliderPair
+///|
+pub fn ColliderPair::ColliderPair(
+  a : ColliderHandle,
+  b : ColliderHandle,
+) -> ColliderPair {
+  ColliderPair::new(a, b)
 }
 
 ///|

--- a/collision/narrow_phase3d_pipeline.mbt
+++ b/collision/narrow_phase3d_pipeline.mbt
@@ -248,8 +248,11 @@ pub struct NarrowPhase3D {
   intersection_pairs : Array[
     ((ColliderHandle3D, ColliderHandle3D), IntersectionPair3D),
   ]
+}
 
-  fn new() -> NarrowPhase3D
+///|
+pub fn NarrowPhase3D::NarrowPhase3D() -> NarrowPhase3D {
+  NarrowPhase3D::new()
 }
 
 ///|

--- a/collision/narrow_phase_pub_parity.mbt
+++ b/collision/narrow_phase_pub_parity.mbt
@@ -37,14 +37,19 @@ pub(all) struct ContactData {
   warmstart_tangent_impulse : @core.Vec2
   // Rapier's dim3-only `warmstart_twist_impulse`.
   warmstart_twist_impulse : @core.Real
+}
 
-  fn new(
-    impulse : @core.Real,
-    tangent_impulse : @core.Vec2,
-    warmstart_impulse : @core.Real,
-    warmstart_tangent_impulse : @core.Vec2,
-    warmstart_twist_impulse : @core.Real,
-  ) -> ContactData
+///|
+pub fn ContactData::ContactData(
+  impulse : @core.Real,
+  tangent_impulse : @core.Vec2,
+  warmstart_impulse : @core.Real,
+  warmstart_tangent_impulse : @core.Vec2,
+  warmstart_twist_impulse : @core.Real,
+) -> ContactData {
+  ContactData::new(
+    impulse, tangent_impulse, warmstart_impulse, warmstart_tangent_impulse, warmstart_twist_impulse,
+  )
 }
 
 ///|
@@ -314,8 +319,11 @@ pub type TemporaryInteractionIndex = Int
 /// Minimal interaction-graph surface for pub parity with Rapier.
 pub struct InteractionGraph[T] {
   interactions : Array[(ColliderHandle, ColliderHandle, T)]
+}
 
-  fn[T] new() -> InteractionGraph[T]
+///|
+pub fn[T] InteractionGraph::InteractionGraph() -> InteractionGraph[T] {
+  InteractionGraph::new()
 }
 
 ///|

--- a/collision/pkg.generated.mbti
+++ b/collision/pkg.generated.mbti
@@ -143,8 +143,6 @@ pub fn ActiveCollisionTypes::test_body_types(Self, @dynamics.RigidBodyType, @dyn
 
 pub struct ActiveEvents {
   mut bits : Int
-
-  fn new(Int) -> ActiveEvents
 }
 pub fn ActiveEvents::collision_events() -> Self
 pub fn ActiveEvents::complement(Self) -> Self
@@ -190,9 +188,8 @@ pub struct BroadPhase3D {
   pairs : Array[(ColliderHandle3D, ColliderHandle3D)]
   prev_pairs : Array[(ColliderHandle3D, ColliderHandle3D)]
   events : Array[BroadPhasePairEvent3D]
-
-  fn new() -> BroadPhase3D
 }
+pub fn BroadPhase3D::BroadPhase3D() -> Self
 pub fn BroadPhase3D::new() -> Self
 pub fn BroadPhase3D::pairs(Self) -> Array[(ColliderHandle3D, ColliderHandle3D)]
 pub fn BroadPhase3D::take_events(Self) -> Array[BroadPhasePairEvent3D]
@@ -204,9 +201,8 @@ pub struct BroadPhaseBvh {
   pairs : Array[(ColliderHandle, ColliderHandle)]
   mut events : Array[BroadPhasePairEvent]
   override_aabbs : Array[(ColliderHandle, @core.Aabb)]
-
-  fn new() -> BroadPhaseBvh
 }
+pub fn BroadPhaseBvh::BroadPhaseBvh() -> Self
 pub fn BroadPhaseBvh::as_query_pipeline(Self, @dynamics.RigidBodySet, ColliderSet, QueryFilter) -> QueryPipeline
 pub fn BroadPhaseBvh::as_query_pipeline_mut(Self, @dynamics.RigidBodySet, ColliderSet, QueryFilter) -> QueryPipelineMut
 pub fn BroadPhaseBvh::new() -> Self
@@ -229,9 +225,8 @@ pub(all) enum BroadPhasePairEvent3D {
 
 pub struct Bvh {
   aabbs : Array[@core.Aabb?]
-
-  fn new(Array[@core.Aabb?]) -> Bvh
 }
+pub fn Bvh::Bvh(Array[@core.Aabb?]) -> Self
 pub fn Bvh::aabbs(Self) -> Array[@core.Aabb?]
 pub fn Bvh::new(Array[@core.Aabb?]) -> Self
 
@@ -562,16 +557,13 @@ pub struct ColliderFlags {
   active_collision_types : ActiveCollisionTypes
   active_hooks : ActiveHooks
   active_events : ActiveEvents
-
-  fn new(@dynamics.InteractionGroups, @dynamics.InteractionGroups, ActiveCollisionTypes, ActiveHooks, ActiveEvents) -> ColliderFlags
 }
+pub fn ColliderFlags::ColliderFlags(@dynamics.InteractionGroups, @dynamics.InteractionGroups, ActiveCollisionTypes, ActiveHooks, ActiveEvents) -> Self
 pub fn ColliderFlags::new(@dynamics.InteractionGroups, @dynamics.InteractionGroups, ActiveCollisionTypes, ActiveHooks, ActiveEvents) -> Self
 
 pub struct ColliderHandle {
   id : Int
   generation : Int
-
-  fn new(Int, Int) -> ColliderHandle
 }
 pub fn ColliderHandle::equals(Self, Self) -> Bool
 pub fn ColliderHandle::from_raw_parts(Int, Int) -> Self
@@ -581,8 +573,6 @@ pub fn ColliderHandle::invalid() -> Self
 pub struct ColliderHandle3D {
   id : Int
   generation : Int
-
-  fn new(Int, Int) -> ColliderHandle3D
 }
 pub fn ColliderHandle3D::equals(Self, Self) -> Bool
 pub fn ColliderHandle3D::from_raw_parts(Int, Int) -> Self
@@ -606,9 +596,8 @@ pub struct ColliderMaterial {
 pub struct ColliderPair {
   collider1 : ColliderHandle
   collider2 : ColliderHandle
-
-  fn new(ColliderHandle, ColliderHandle) -> ColliderPair
 }
+pub fn ColliderPair::ColliderPair(ColliderHandle, ColliderHandle) -> Self
 pub fn ColliderPair::collider1(Self) -> ColliderHandle
 pub fn ColliderPair::collider2(Self) -> ColliderHandle
 pub fn ColliderPair::new(ColliderHandle, ColliderHandle) -> Self
@@ -617,9 +606,8 @@ pub fn ColliderPair::swap(Self) -> Self
 pub struct ColliderPair3D {
   collider1 : ColliderHandle3D
   collider2 : ColliderHandle3D
-
-  fn new(ColliderHandle3D, ColliderHandle3D) -> ColliderPair3D
 }
+pub fn ColliderPair3D::ColliderPair3D(ColliderHandle3D, ColliderHandle3D) -> Self
 pub fn ColliderPair3D::collider1(Self) -> ColliderHandle3D
 pub fn ColliderPair3D::collider2(Self) -> ColliderHandle3D
 pub fn ColliderPair3D::new(ColliderHandle3D, ColliderHandle3D) -> Self
@@ -627,16 +615,14 @@ pub fn ColliderPair3D::new(ColliderHandle3D, ColliderHandle3D) -> Self
 pub struct ColliderParent {
   handle : @dynamics.RigidBodyHandle
   pos_wrt_parent : @core.Isometry2
-
-  fn new(@dynamics.RigidBodyHandle, @core.Isometry2) -> ColliderParent
 }
+pub fn ColliderParent::ColliderParent(@dynamics.RigidBodyHandle, @core.Isometry2) -> Self
 pub fn ColliderParent::new(@dynamics.RigidBodyHandle, @core.Isometry2) -> Self
 
 pub struct ColliderPosition {
   position : @core.Isometry2
-
-  fn new(@core.Isometry2) -> ColliderPosition
 }
+pub fn ColliderPosition::ColliderPosition(@core.Isometry2) -> Self
 pub fn ColliderPosition::new(@core.Isometry2) -> Self
 
 pub struct ColliderSet {
@@ -645,9 +631,8 @@ pub struct ColliderSet {
   free_list : Array[Int]
   modified_colliders : Array[ColliderHandle]
   mut removed_colliders : Array[ColliderHandle]
-
-  fn new() -> ColliderSet
 }
+pub fn ColliderSet::ColliderSet() -> Self
 pub fn ColliderSet::apply_pending_body_position_propagation(Self, @dynamics.RigidBodySet) -> Unit
 pub fn ColliderSet::clear_changes_for(Self, Array[ColliderHandle]) -> Unit
 pub fn ColliderSet::colliders_with_parent(Self, @dynamics.RigidBodyHandle) -> Array[ColliderHandle]
@@ -673,9 +658,8 @@ pub fn ColliderSet::take_removed(Self) -> Array[ColliderHandle]
 
 pub struct ColliderSet3 {
   inner : ColliderSet
-
-  fn new() -> ColliderSet3
 }
+pub fn ColliderSet3::ColliderSet3() -> Self
 pub fn ColliderSet3::as_2d(Self) -> ColliderSet
 pub fn ColliderSet3::clear_changes_for(Self, Array[ColliderHandle]) -> Unit
 pub fn ColliderSet3::colliders_with_parent(Self, @dynamics.RigidBodyHandle) -> Array[ColliderHandle]
@@ -693,9 +677,8 @@ pub struct ColliderSet3D {
   colliders : Array[Collider3D?]
   generations : Array[Int]
   free_list : Array[Int]
-
-  fn new() -> ColliderSet3D
 }
+pub fn ColliderSet3D::ColliderSet3D() -> Self
 pub fn ColliderSet3D::all_handles(Self) -> Array[ColliderHandle3D]
 pub fn ColliderSet3D::get(Self, ColliderHandle3D) -> Collider3D?
 pub fn ColliderSet3D::get_mut(Self, ColliderHandle3D) -> Collider3D?
@@ -738,8 +721,6 @@ pub fn CollisionEvent3D::stopped(Self) -> Bool
 
 pub struct CollisionEventFlags {
   mut bits : Int
-
-  fn new(Int) -> CollisionEventFlags
 }
 pub fn CollisionEventFlags::contains(Self, Self) -> Bool
 pub fn CollisionEventFlags::empty() -> Self
@@ -753,9 +734,8 @@ pub(all) struct ContactData {
   warmstart_impulse : Float
   warmstart_tangent_impulse : @core.Vec2
   warmstart_twist_impulse : Float
-
-  fn new(Float, @core.Vec2, Float, @core.Vec2, Float) -> ContactData
 }
+pub fn ContactData::ContactData(Float, @core.Vec2, Float, @core.Vec2, Float) -> Self
 pub fn ContactData::default() -> Self
 pub fn ContactData::new(Float, @core.Vec2, Float, @core.Vec2, Float) -> Self
 
@@ -766,9 +746,8 @@ pub struct ContactForceEvent {
   total_force_magnitude : Float
   max_force_direction : @core.Vec2
   max_force_magnitude : Float
-
-  fn new(ColliderHandle, ColliderHandle, @core.Vec2, Float, @core.Vec2, Float) -> ContactForceEvent
 }
+pub fn ContactForceEvent::ContactForceEvent(ColliderHandle, ColliderHandle, @core.Vec2, Float, @core.Vec2, Float) -> Self
 pub fn ContactForceEvent::collider1(Self) -> ColliderHandle
 pub fn ContactForceEvent::collider2(Self) -> ColliderHandle
 pub fn ContactForceEvent::from_contact_pair(Float, ColliderHandle, ColliderHandle, ContactPair, Float) -> Self
@@ -785,9 +764,8 @@ pub struct ContactForceEvent3D {
   total_force_magnitude : Float
   max_force_direction : @core.Vec3
   max_force_magnitude : Float
-
-  fn new(ColliderHandle3D, ColliderHandle3D, @core.Vec3, Float, @core.Vec3, Float) -> ContactForceEvent3D
 }
+pub fn ContactForceEvent3D::ContactForceEvent3D(ColliderHandle3D, ColliderHandle3D, @core.Vec3, Float, @core.Vec3, Float) -> Self
 pub fn ContactForceEvent3D::collider1(Self) -> ColliderHandle3D
 pub fn ContactForceEvent3D::collider2(Self) -> ColliderHandle3D
 pub fn ContactForceEvent3D::from_contact_pair(Float, ColliderHandle3D, ColliderHandle3D, ContactPair3D, Float) -> Self
@@ -800,9 +778,8 @@ pub fn ContactForceEvent3D::total_force_magnitude(Self) -> Float
 pub struct ContactManifold {
   normal : @core.Vec2
   points : Array[ContactManifoldPoint]
-
-  fn new(@core.Vec2, Array[ContactManifoldPoint]) -> ContactManifold
 }
+pub fn ContactManifold::ContactManifold(@core.Vec2, Array[ContactManifoldPoint]) -> Self
 pub fn ContactManifold::new(@core.Vec2, Array[ContactManifoldPoint]) -> Self
 pub fn ContactManifold::normal(Self) -> @core.Vec2
 pub fn ContactManifold::points(Self) -> Array[ContactManifoldPoint]
@@ -878,17 +855,15 @@ pub fn FillMode::surface_only() -> Self
 pub struct HeightField {
   heights : Array[Float]
   scale : @core.Vec2
-
-  fn new(Array[Float], @core.Vec2) -> HeightField
 }
+pub fn HeightField::HeightField(Array[Float], @core.Vec2) -> Self
 pub fn HeightField::as_shape(Self) -> Shape
 pub fn HeightField::new(Array[Float], @core.Vec2) -> Self
 
 pub struct InteractionGraph[T] {
   interactions : Array[(ColliderHandle, ColliderHandle, T)]
-
-  fn[T] new() -> InteractionGraph[T]
 }
+pub fn[T] InteractionGraph::InteractionGraph() -> Self[T]
 pub fn[T] InteractionGraph::index_interaction(Self[T], ColliderHandle, ColliderHandle) -> Int?
 pub fn[T] InteractionGraph::interaction_pair(Self[T], ColliderHandle, ColliderHandle) -> T?
 pub fn[T] InteractionGraph::interaction_pair_mut(Self[T], ColliderHandle, ColliderHandle) -> T?
@@ -903,9 +878,8 @@ pub struct IntersectionEvent {
   collider1 : ColliderHandle
   collider2 : ColliderHandle
   intersecting : Bool
-
-  fn new(ColliderHandle, ColliderHandle, Bool) -> IntersectionEvent
 }
+pub fn IntersectionEvent::IntersectionEvent(ColliderHandle, ColliderHandle, Bool) -> Self
 pub fn IntersectionEvent::collider1(Self) -> ColliderHandle
 pub fn IntersectionEvent::collider2(Self) -> ColliderHandle
 pub fn IntersectionEvent::intersecting(Self) -> Bool
@@ -915,9 +889,8 @@ pub struct IntersectionEvent3D {
   collider1 : ColliderHandle3D
   collider2 : ColliderHandle3D
   intersecting : Bool
-
-  fn new(ColliderHandle3D, ColliderHandle3D, Bool) -> IntersectionEvent3D
 }
+pub fn IntersectionEvent3D::IntersectionEvent3D(ColliderHandle3D, ColliderHandle3D, Bool) -> Self
 pub fn IntersectionEvent3D::collider1(Self) -> ColliderHandle3D
 pub fn IntersectionEvent3D::collider2(Self) -> ColliderHandle3D
 pub fn IntersectionEvent3D::intersecting(Self) -> Bool
@@ -966,9 +939,8 @@ pub struct NarrowPhase {
   mut intersections : Array[IntersectionPair]
   mut contacts : Array[(ColliderHandle, ColliderHandle, ContactPair)]
   mut query_dispatcher : QueryDispatcher
-
-  fn new() -> NarrowPhase
 }
+pub fn NarrowPhase::NarrowPhase() -> Self
 pub fn NarrowPhase::contact_graph(Self) -> InteractionGraph[ContactPair]
 pub fn NarrowPhase::contact_pair(Self, ColliderHandle, ColliderHandle) -> ContactPair?
 pub fn NarrowPhase::contact_pair_at_index(Self, Int) -> (ColliderHandle, ColliderHandle, ContactPair)?
@@ -993,9 +965,8 @@ pub fn NarrowPhase::with_query_dispatcher(Self, QueryDispatcher) -> Self
 pub struct NarrowPhase3D {
   contact_pairs : Array[((ColliderHandle3D, ColliderHandle3D), ContactPair3D)]
   intersection_pairs : Array[((ColliderHandle3D, ColliderHandle3D), IntersectionPair3D)]
-
-  fn new() -> NarrowPhase3D
 }
+pub fn NarrowPhase3D::NarrowPhase3D() -> Self
 pub fn NarrowPhase3D::all_contact_pairs(Self) -> Array[((ColliderHandle3D, ColliderHandle3D), ContactPair3D)]
 pub fn NarrowPhase3D::all_intersection_pairs(Self) -> Array[((ColliderHandle3D, ColliderHandle3D), IntersectionPair3D)]
 pub fn NarrowPhase3D::clear(Self) -> Unit
@@ -1009,9 +980,8 @@ pub struct NonlinearRigidMotion {
   start_pos : @core.Isometry2
   linvel : @core.Vec2
   angvel : Float
-
-  fn new(@core.Isometry2, @core.Vec2, Float) -> NonlinearRigidMotion
 }
+pub fn NonlinearRigidMotion::NonlinearRigidMotion(@core.Isometry2, @core.Vec2, Float) -> Self
 pub fn NonlinearRigidMotion::identity() -> Self
 pub fn NonlinearRigidMotion::new(@core.Isometry2, @core.Vec2, Float) -> Self
 
@@ -1039,9 +1009,8 @@ pub struct QueryFilter {
   mut groups : @dynamics.InteractionGroups?
   mut flags : QueryFilterFlags
   mut predicate : ((ColliderHandle, Collider) -> Bool)?
-
-  fn new() -> QueryFilter
 }
+pub fn QueryFilter::QueryFilter() -> Self
 pub fn QueryFilter::exclude_collider(Self, ColliderHandle) -> Self
 pub fn QueryFilter::exclude_dynamic(Self) -> Self
 pub fn QueryFilter::exclude_fixed(Self) -> Self
@@ -1064,9 +1033,8 @@ pub struct QueryFilter3DReal {
   mut groups : @dynamics.InteractionGroups?
   mut flags : QueryFilterFlags
   mut predicate : ((ColliderHandle3D, Collider3D) -> Bool)?
-
-  fn new() -> QueryFilter3DReal
 }
+pub fn QueryFilter3DReal::QueryFilter3DReal() -> Self
 pub fn QueryFilter3DReal::exclude_collider(Self, ColliderHandle3D) -> Self
 pub fn QueryFilter3DReal::exclude_dynamic(Self) -> Self
 pub fn QueryFilter3DReal::exclude_fixed(Self) -> Self
@@ -1083,9 +1051,8 @@ pub fn QueryFilter3DReal::predicate(Self, (ColliderHandle3D, Collider3D) -> Bool
 
 pub struct QueryFilterFlags {
   mut bits : Int
-
-  fn new(Int) -> QueryFilterFlags
 }
+pub fn QueryFilterFlags::QueryFilterFlags(Int) -> Self
 pub fn QueryFilterFlags::complement(Self) -> Self
 pub fn QueryFilterFlags::contains(Self, Int) -> Bool
 pub fn QueryFilterFlags::difference(Self, Self) -> Self
@@ -1115,9 +1082,8 @@ pub struct QueryPipeline {
   bvh : Bvh
   filter : QueryFilter
   dispatcher : QueryDispatcher
-
-  fn new(QueryFilter, @dynamics.RigidBodySet, ColliderSet) -> QueryPipeline
 }
+pub fn QueryPipeline::QueryPipeline(QueryFilter, @dynamics.RigidBodySet, ColliderSet) -> Self
 pub fn QueryPipeline::cast_ray(Self, @dynamics.RigidBodySet, ColliderSet, Ray, Float, Bool) -> (ColliderHandle, Float)?
 pub fn QueryPipeline::cast_ray_and_get_normal(Self, @dynamics.RigidBodySet, ColliderSet, Ray, Float, Bool) -> (ColliderHandle, RayIntersection)?
 pub fn QueryPipeline::cast_shape(Self, @dynamics.RigidBodySet, ColliderSet, @core.Isometry2, @core.Vec2, Shape, ShapeCastOptions) -> (ColliderHandle, ShapeCastHit)?
@@ -1139,9 +1105,8 @@ pub fn QueryPipeline::with_filter(Self, QueryFilter) -> Self
 pub struct QueryPipeline3DReal {
   filter : QueryFilter3DReal
   mut cached_aabbs : Array[@core.Aabb3?]
-
-  fn new(QueryFilter3DReal, @dynamics.RigidBodySet3D, ColliderSet3D) -> QueryPipeline3DReal
 }
+pub fn QueryPipeline3DReal::QueryPipeline3DReal(QueryFilter3DReal, @dynamics.RigidBodySet3D, ColliderSet3D) -> Self
 pub fn QueryPipeline3DReal::cast_ray(Self, @dynamics.RigidBodySet3D, ColliderSet3D, Ray3, Float, Bool) -> (ColliderHandle3D, Float)?
 pub fn QueryPipeline3DReal::cast_ray_and_get_normal(Self, @dynamics.RigidBodySet3D, ColliderSet3D, Ray3, Float, Bool) -> (ColliderHandle3D, RayIntersection3)?
 pub fn QueryPipeline3DReal::cast_ray_and_get_normal_and_feature(Self, @dynamics.RigidBodySet3D, ColliderSet3D, Ray3, Float, Bool) -> (ColliderHandle3D, RayIntersection3Feature)?
@@ -1162,9 +1127,8 @@ pub fn QueryPipeline3DReal::with_filter(Self, QueryFilter3DReal) -> Self
 pub struct QueryPipelineMut {
   pipeline : QueryPipeline
   dispatcher : QueryDispatcher
-
-  fn new(QueryFilter, @dynamics.RigidBodySet, ColliderSet) -> QueryPipelineMut
 }
+pub fn QueryPipelineMut::QueryPipelineMut(QueryFilter, @dynamics.RigidBodySet, ColliderSet) -> Self
 pub fn QueryPipelineMut::as_ref(Self) -> QueryPipeline
 pub fn QueryPipelineMut::new(QueryFilter, @dynamics.RigidBodySet, ColliderSet) -> Self
 pub fn QueryPipelineMut::new3(QueryFilter, @dynamics.RigidBodySet3, ColliderSet3) -> Self
@@ -1172,9 +1136,8 @@ pub fn QueryPipelineMut::update(Self, @dynamics.RigidBodySet, ColliderSet) -> Un
 
 pub struct QueryPipelineMut3DReal {
   pipeline : QueryPipeline3DReal
-
-  fn new(QueryFilter3DReal, @dynamics.RigidBodySet3D, ColliderSet3D) -> QueryPipelineMut3DReal
 }
+pub fn QueryPipelineMut3DReal::QueryPipelineMut3DReal(QueryFilter3DReal, @dynamics.RigidBodySet3D, ColliderSet3D) -> Self
 pub fn QueryPipelineMut3DReal::as_ref(Self) -> QueryPipeline3DReal
 pub fn QueryPipelineMut3DReal::new(QueryFilter3DReal, @dynamics.RigidBodySet3D, ColliderSet3D) -> Self
 pub fn QueryPipelineMut3DReal::update(Self, @dynamics.RigidBodySet3D, ColliderSet3D) -> Unit
@@ -1182,17 +1145,15 @@ pub fn QueryPipelineMut3DReal::update(Self, @dynamics.RigidBodySet3D, ColliderSe
 pub struct Ray {
   origin : @core.Vec2
   dir : @core.Vec2
-
-  fn new(@core.Vec2, @core.Vec2) -> Ray
 }
+pub fn Ray::Ray(@core.Vec2, @core.Vec2) -> Self
 pub fn Ray::new(@core.Vec2, @core.Vec2) -> Self
 
 pub struct Ray3 {
   origin : @core.Vec3
   dir : @core.Vec3
-
-  fn new(@core.Vec3, @core.Vec3) -> Ray3
 }
+pub fn Ray3::Ray3(@core.Vec3, @core.Vec3) -> Self
 pub fn Ray3::new(@core.Vec3, @core.Vec3) -> Self
 
 pub struct RayIntersection {
@@ -1281,9 +1242,8 @@ pub struct ShapeCastOptions {
   max_toi : Float
   target_distance : Float
   stop_at_penetration : Bool
-
-  fn new(Float, Bool) -> ShapeCastOptions
 }
+pub fn ShapeCastOptions::ShapeCastOptions(Float, Bool) -> Self
 pub fn ShapeCastOptions::max_toi(Self) -> Float
 pub fn ShapeCastOptions::new(Float, Bool) -> Self
 pub fn ShapeCastOptions::stop_at_penetration(Self) -> Bool
@@ -1294,9 +1254,8 @@ pub struct ShapeCastOptions3 {
   max_toi : Float
   target_distance : Float
   stop_at_penetration : Bool
-
-  fn new(Float, Bool) -> ShapeCastOptions3
 }
+pub fn ShapeCastOptions3::ShapeCastOptions3(Float, Bool) -> Self
 pub fn ShapeCastOptions3::max_toi(Self) -> Float
 pub fn ShapeCastOptions3::new(Float, Bool) -> Self
 pub fn ShapeCastOptions3::stop_at_penetration(Self) -> Bool
@@ -1306,9 +1265,8 @@ pub fn ShapeCastOptions3::with_target_distance(Self, Float) -> Self
 #alias(ColliderShape)
 pub struct SharedShape {
   shape : Shape
-
-  fn new(Shape) -> SharedShape
 }
+pub fn SharedShape::SharedShape(Shape) -> Self
 pub fn SharedShape::as_shape(Self) -> Shape
 pub fn SharedShape::ball(Float) -> Self
 pub fn SharedShape::capsule_x(Float, Float) -> Self
@@ -1327,9 +1285,8 @@ pub struct SolverContact {
   mut friction : Float
   mut restitution : Float
   mut tangent_velocity : @core.Vec2
-
-  fn new(@core.Vec2, Float) -> SolverContact
 }
+pub fn SolverContact::SolverContact(@core.Vec2, Float) -> Self
 pub fn SolverContact::dist(Self) -> Float
 pub fn SolverContact::friction(Self) -> Float
 pub fn SolverContact::new(@core.Vec2, Float) -> Self
@@ -1378,9 +1335,8 @@ pub struct Triangle {
   a : @core.Vec2
   b : @core.Vec2
   c : @core.Vec2
-
-  fn new(@core.Vec2, @core.Vec2, @core.Vec2) -> Triangle
 }
+pub fn Triangle::Triangle(@core.Vec2, @core.Vec2, @core.Vec2) -> Self
 pub fn Triangle::as_shape(Self) -> Shape
 pub fn Triangle::new(@core.Vec2, @core.Vec2, @core.Vec2) -> Self
 

--- a/collision/query_pipeline.mbt
+++ b/collision/query_pipeline.mbt
@@ -47,8 +47,11 @@ const QUERY_FILTER_ONLY_FIXED : Int = QUERY_FILTER_EXCLUDE_DYNAMIC |
 ///|
 pub struct QueryFilterFlags {
   mut bits : Int
+}
 
-  fn new(bits : Int) -> QueryFilterFlags
+///|
+pub fn QueryFilterFlags::QueryFilterFlags(bits : Int) -> QueryFilterFlags {
+  QueryFilterFlags::new(bits)
 }
 
 ///|
@@ -272,8 +275,11 @@ pub struct QueryFilter {
   mut groups : @dynamics.InteractionGroups?
   mut flags : QueryFilterFlags
   mut predicate : ((ColliderHandle, Collider) -> Bool)?
+}
 
-  fn new() -> QueryFilter
+///|
+pub fn QueryFilter::QueryFilter() -> QueryFilter {
+  QueryFilter::new()
 }
 
 ///|
@@ -432,8 +438,11 @@ pub struct Bvh {
   // Rapier's "conservative" AABB queries which do not recompute the latest
   // collider AABB.
   aabbs : Array[@core.Aabb?]
+}
 
-  fn new(aabbs : Array[@core.Aabb?]) -> Bvh
+///|
+pub fn Bvh::Bvh(aabbs : Array[@core.Aabb?]) -> Bvh {
+  Bvh::new(aabbs)
 }
 
 ///|
@@ -456,24 +465,30 @@ pub struct QueryPipeline {
   bvh : Bvh
   filter : QueryFilter
   dispatcher : QueryDispatcher
+}
 
-  fn new(
-    filter : QueryFilter,
-    bodies : @dynamics.RigidBodySet,
-    colliders : ColliderSet,
-  ) -> QueryPipeline
+///|
+pub fn QueryPipeline::QueryPipeline(
+  filter : QueryFilter,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
+) -> QueryPipeline {
+  QueryPipeline::new(filter, bodies, colliders)
 }
 
 ///|
 pub struct QueryPipelineMut {
   pipeline : QueryPipeline
   dispatcher : QueryDispatcher
+}
 
-  fn new(
-    filter : QueryFilter,
-    bodies : @dynamics.RigidBodySet,
-    colliders : ColliderSet,
-  ) -> QueryPipelineMut
+///|
+pub fn QueryPipelineMut::QueryPipelineMut(
+  filter : QueryFilter,
+  bodies : @dynamics.RigidBodySet,
+  colliders : ColliderSet,
+) -> QueryPipelineMut {
+  QueryPipelineMut::new(filter, bodies, colliders)
 }
 
 ///|
@@ -529,8 +544,14 @@ pub struct ShapeCastOptions {
   max_toi : @core.Real
   target_distance : @core.Real
   stop_at_penetration : Bool
+}
 
-  fn new(max_toi : @core.Real, stop_at_penetration : Bool) -> ShapeCastOptions
+///|
+pub fn ShapeCastOptions::ShapeCastOptions(
+  max_toi : @core.Real,
+  stop_at_penetration : Bool,
+) -> ShapeCastOptions {
+  ShapeCastOptions::new(max_toi, stop_at_penetration)
 }
 
 ///|
@@ -574,12 +595,15 @@ pub struct NonlinearRigidMotion {
   start_pos : @core.Isometry2
   linvel : @core.Vec2
   angvel : @core.Real
+}
 
-  fn new(
-    start_pos : @core.Isometry2,
-    linvel : @core.Vec2,
-    angvel : @core.Real,
-  ) -> NonlinearRigidMotion
+///|
+pub fn NonlinearRigidMotion::NonlinearRigidMotion(
+  start_pos : @core.Isometry2,
+  linvel : @core.Vec2,
+  angvel : @core.Real,
+) -> NonlinearRigidMotion {
+  NonlinearRigidMotion::new(start_pos, linvel, angvel)
 }
 
 ///|

--- a/collision/query_pipeline3d_real.mbt
+++ b/collision/query_pipeline3d_real.mbt
@@ -20,8 +20,11 @@
 pub struct Ray3 {
   origin : @core.Vec3
   dir : @core.Vec3
+}
 
-  fn new(origin : @core.Vec3, dir : @core.Vec3) -> Ray3
+///|
+pub fn Ray3::Ray3(origin : @core.Vec3, dir : @core.Vec3) -> Ray3 {
+  Ray3::new(origin, dir)
 }
 
 ///|
@@ -116,8 +119,14 @@ pub struct ShapeCastOptions3 {
   max_toi : @core.Real
   target_distance : @core.Real
   stop_at_penetration : Bool
+}
 
-  fn new(max_toi : @core.Real, stop_at_penetration : Bool) -> ShapeCastOptions3
+///|
+pub fn ShapeCastOptions3::ShapeCastOptions3(
+  max_toi : @core.Real,
+  stop_at_penetration : Bool,
+) -> ShapeCastOptions3 {
+  ShapeCastOptions3::new(max_toi, stop_at_penetration)
 }
 
 ///|
@@ -192,8 +201,11 @@ pub struct QueryFilter3DReal {
   mut groups : @dynamics.InteractionGroups?
   mut flags : QueryFilterFlags
   mut predicate : ((ColliderHandle3D, Collider3D) -> Bool)?
+}
 
-  fn new() -> QueryFilter3DReal
+///|
+pub fn QueryFilter3DReal::QueryFilter3DReal() -> QueryFilter3DReal {
+  QueryFilter3DReal::new()
 }
 
 ///|
@@ -382,23 +394,29 @@ pub struct QueryPipeline3DReal {
   filter : QueryFilter3DReal
   // Cached world-space AABBs to accelerate repeated queries (e.g. character controller).
   mut cached_aabbs : Array[@core.Aabb3?]
+}
 
-  fn new(
-    filter : QueryFilter3DReal,
-    bodies : @dynamics.RigidBodySet3D,
-    colliders : ColliderSet3D,
-  ) -> QueryPipeline3DReal
+///|
+pub fn QueryPipeline3DReal::QueryPipeline3DReal(
+  filter : QueryFilter3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
+) -> QueryPipeline3DReal {
+  QueryPipeline3DReal::new(filter, bodies, colliders)
 }
 
 ///|
 pub struct QueryPipelineMut3DReal {
   pipeline : QueryPipeline3DReal
+}
 
-  fn new(
-    filter : QueryFilter3DReal,
-    bodies : @dynamics.RigidBodySet3D,
-    colliders : ColliderSet3D,
-  ) -> QueryPipelineMut3DReal
+///|
+pub fn QueryPipelineMut3DReal::QueryPipelineMut3DReal(
+  filter : QueryFilter3DReal,
+  bodies : @dynamics.RigidBodySet3D,
+  colliders : ColliderSet3D,
+) -> QueryPipelineMut3DReal {
+  QueryPipelineMut3DReal::new(filter, bodies, colliders)
 }
 
 ///|

--- a/collision/solver_contacts.mbt
+++ b/collision/solver_contacts.mbt
@@ -63,8 +63,14 @@ pub struct SolverContact {
   mut friction : @core.Real
   mut restitution : @core.Real
   mut tangent_velocity : @core.Vec2
+}
 
-  fn new(point : @core.Vec2, dist : @core.Real) -> SolverContact
+///|
+pub fn SolverContact::SolverContact(
+  point : @core.Vec2,
+  dist : @core.Real,
+) -> SolverContact {
+  SolverContact::new(point, dist)
 }
 
 ///|

--- a/collision/spec.mbt
+++ b/collision/spec.mbt
@@ -1872,8 +1872,11 @@ pub fn QueryFilterFlags::insert(
 pub struct Ray {
   origin : @core.Vec2
   dir : @core.Vec2
+}
 
-  fn new(origin : @core.Vec2, dir : @core.Vec2) -> Ray
+///|
+pub fn Ray::Ray(origin : @core.Vec2, dir : @core.Vec2) -> Ray {
+  Ray::new(origin, dir)
 }
 
 ///|

--- a/control/character_controller.mbt
+++ b/control/character_controller.mbt
@@ -104,11 +104,14 @@ pub struct CharacterAutostep {
   max_height : CharacterLength
   min_width : CharacterLength
   include_dynamic_bodies : Bool
+}
 
-  fn new(
-    max_height : CharacterLength,
-    min_width : CharacterLength,
-  ) -> CharacterAutostep
+///|
+pub fn CharacterAutostep::CharacterAutostep(
+  max_height : CharacterLength,
+  min_width : CharacterLength,
+) -> CharacterAutostep {
+  CharacterAutostep::new(max_height, min_width)
 }
 
 ///|
@@ -203,8 +206,11 @@ pub struct KinematicCharacterController {
   snap_to_ground : CharacterLength?
   autostep : CharacterAutostep?
   normal_nudge_factor : @core.Real
+}
 
-  fn new() -> KinematicCharacterController
+///|
+pub fn KinematicCharacterController::KinematicCharacterController() -> KinematicCharacterController {
+  KinematicCharacterController::new()
 }
 
 ///|

--- a/control/character_controller3d_real.mbt
+++ b/control/character_controller3d_real.mbt
@@ -100,8 +100,11 @@ pub struct KinematicCharacterController3DReal {
   min_slope_slide_angle : @core.Real
   snap_to_ground : CharacterLength?
   normal_nudge_factor : @core.Real
+}
 
-  fn new() -> KinematicCharacterController3DReal
+///|
+pub fn KinematicCharacterController3DReal::KinematicCharacterController3DReal() -> KinematicCharacterController3DReal {
+  KinematicCharacterController3DReal::new()
 }
 
 ///|

--- a/control/pid_controller.mbt
+++ b/control/pid_controller.mbt
@@ -30,12 +30,15 @@ pub(all) struct PdController {
   ang_kp : @core.Real
   ang_kd : @core.Real
   axes : @dynamics.AxesMask
+}
 
-  fn new(
-    kp : @core.Real,
-    kd : @core.Real,
-    axes : @dynamics.AxesMask,
-  ) -> PdController
+///|
+pub fn PdController::PdController(
+  kp : @core.Real,
+  kd : @core.Real,
+  axes : @dynamics.AxesMask,
+) -> PdController {
+  PdController::new(kp, kd, axes)
 }
 
 ///|
@@ -207,13 +210,16 @@ pub(all) struct PidController {
   mut ang_integral : @core.Real
   lin_ki : @core.Vec2
   ang_ki : @core.Real
+}
 
-  fn new(
-    kp : @core.Real,
-    ki : @core.Real,
-    kd : @core.Real,
-    axes : @dynamics.AxesMask,
-  ) -> PidController
+///|
+pub fn PidController::PidController(
+  kp : @core.Real,
+  ki : @core.Real,
+  kd : @core.Real,
+  axes : @dynamics.AxesMask,
+) -> PidController {
+  PidController::new(kp, ki, kd, axes)
 }
 
 ///|

--- a/control/pkg.generated.mbti
+++ b/control/pkg.generated.mbti
@@ -16,9 +16,8 @@ pub struct CharacterAutostep {
   max_height : CharacterLength
   min_width : CharacterLength
   include_dynamic_bodies : Bool
-
-  fn new(CharacterLength, CharacterLength) -> CharacterAutostep
 }
+pub fn CharacterAutostep::CharacterAutostep(CharacterLength, CharacterLength) -> Self
 pub fn CharacterAutostep::default() -> Self
 pub fn CharacterAutostep::include_dynamic_bodies(Self) -> Bool
 pub fn CharacterAutostep::max_height(Self) -> CharacterLength
@@ -66,9 +65,8 @@ pub struct DynamicRayCastVehicleController {
   chassis : @dynamics.RigidBodyHandle
   index_up_axis : Int
   index_forward_axis : Int
-
-  fn new(@dynamics.RigidBodyHandle) -> DynamicRayCastVehicleController
 }
+pub fn DynamicRayCastVehicleController::DynamicRayCastVehicleController(@dynamics.RigidBodyHandle) -> Self
 pub fn DynamicRayCastVehicleController::add_wheel(Self, @core.Vec2, @core.Vec2, Float, Float, WheelTuning) -> Unit
 pub fn DynamicRayCastVehicleController::new(@dynamics.RigidBodyHandle) -> Self
 pub fn DynamicRayCastVehicleController::set_brake(Self, Int, Float) -> Unit
@@ -83,9 +81,8 @@ pub struct DynamicRayCastVehicleController3 {
   chassis : @dynamics.RigidBodyHandle
   index_up_axis : Int
   index_forward_axis : Int
-
-  fn new(@dynamics.RigidBodyHandle) -> DynamicRayCastVehicleController3
 }
+pub fn DynamicRayCastVehicleController3::DynamicRayCastVehicleController3(@dynamics.RigidBodyHandle) -> Self
 pub fn DynamicRayCastVehicleController3::add_wheel(Self, @core.Vec3, @core.Vec3, @core.Vec3, Float, Float, WheelTuning) -> Int
 pub fn DynamicRayCastVehicleController3::new(@dynamics.RigidBodyHandle) -> Self
 pub fn DynamicRayCastVehicleController3::set_brake(Self, Int, Float) -> Unit
@@ -102,9 +99,8 @@ pub struct DynamicRayCastVehicleController3DReal {
   chassis : @dynamics.RigidBodyHandle
   index_up_axis : Int
   index_forward_axis : Int
-
-  fn new(@dynamics.RigidBodyHandle) -> DynamicRayCastVehicleController3DReal
 }
+pub fn DynamicRayCastVehicleController3DReal::DynamicRayCastVehicleController3DReal(@dynamics.RigidBodyHandle) -> Self
 pub fn DynamicRayCastVehicleController3DReal::add_wheel(Self, @core.Vec3, @core.Vec3, @core.Vec3, Float, Float, WheelTuning) -> Int
 pub fn DynamicRayCastVehicleController3DReal::new(@dynamics.RigidBodyHandle) -> Self
 pub fn DynamicRayCastVehicleController3DReal::set_brake(Self, Int, Float) -> Unit
@@ -142,9 +138,8 @@ pub struct KinematicCharacterController {
   snap_to_ground : CharacterLength?
   autostep : CharacterAutostep?
   normal_nudge_factor : Float
-
-  fn new() -> KinematicCharacterController
 }
+pub fn KinematicCharacterController::KinematicCharacterController() -> Self
 pub fn KinematicCharacterController::default() -> Self
 pub fn KinematicCharacterController::move_shape(Self, Float, @collision.QueryPipeline, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.Shape, @core.Isometry2, @core.Vec2, (CharacterCollision) -> Unit) -> EffectiveMovement
 pub fn KinematicCharacterController::new() -> Self
@@ -167,9 +162,8 @@ pub struct KinematicCharacterController3DReal {
   min_slope_slide_angle : Float
   snap_to_ground : CharacterLength?
   normal_nudge_factor : Float
-
-  fn new() -> KinematicCharacterController3DReal
 }
+pub fn KinematicCharacterController3DReal::KinematicCharacterController3DReal() -> Self
 pub fn KinematicCharacterController3DReal::default() -> Self
 pub fn KinematicCharacterController3DReal::move_shape(Self, Float, @collision.QueryPipeline3DReal, @dynamics.RigidBodySet3D, @collision.ColliderSet3D, @collision.Shape3D, @core.Isometry3, @core.Vec3, (CharacterCollision3DReal) -> Unit) -> EffectiveMovement3DReal
 pub fn KinematicCharacterController3DReal::new() -> Self
@@ -189,9 +183,8 @@ pub(all) struct PdController {
   ang_kp : Float
   ang_kd : Float
   axes : @dynamics.AxesMask
-
-  fn new(Float, Float, @dynamics.AxesMask) -> PdController
 }
+pub fn PdController::PdController(Float, Float, @dynamics.AxesMask) -> Self
 pub fn PdController::angular_rigid_body_correction(Self, @dynamics.RigidBody, @core.Rot2, Float) -> Float
 pub fn PdController::correction(Self, PdErrors, PdErrors) -> @dynamics.RigidBodyVelocity
 pub fn PdController::default() -> Self
@@ -211,9 +204,8 @@ pub(all) struct PidController {
   mut ang_integral : Float
   lin_ki : @core.Vec2
   ang_ki : Float
-
-  fn new(Float, Float, Float, @dynamics.AxesMask) -> PidController
 }
+pub fn PidController::PidController(Float, Float, Float, @dynamics.AxesMask) -> Self
 pub fn PidController::angular_rigid_body_correction(Self, Float, @dynamics.RigidBody, @core.Rot2, Float) -> Float
 pub fn PidController::axes(Self) -> @dynamics.AxesMask
 pub fn PidController::correction(Self, Float, PdErrors, PdErrors) -> @dynamics.RigidBodyVelocity

--- a/control/ray_cast_vehicle_controller.mbt
+++ b/control/ray_cast_vehicle_controller.mbt
@@ -266,8 +266,13 @@ pub struct DynamicRayCastVehicleController {
   chassis : @dynamics.RigidBodyHandle
   index_up_axis : Int
   index_forward_axis : Int
+}
 
-  fn new(chassis : @dynamics.RigidBodyHandle) -> DynamicRayCastVehicleController
+///|
+pub fn DynamicRayCastVehicleController::DynamicRayCastVehicleController(
+  chassis : @dynamics.RigidBodyHandle,
+) -> DynamicRayCastVehicleController {
+  DynamicRayCastVehicleController::new(chassis)
 }
 
 ///|

--- a/control/ray_cast_vehicle_controller3.mbt
+++ b/control/ray_cast_vehicle_controller3.mbt
@@ -156,10 +156,13 @@ pub struct DynamicRayCastVehicleController3 {
   index_up_axis : Int
   /// The chassis local forward direction (`0 = x, 1 = y, 2 = z`).
   index_forward_axis : Int
+}
 
-  fn new(
-    chassis : @dynamics.RigidBodyHandle,
-  ) -> DynamicRayCastVehicleController3
+///|
+pub fn DynamicRayCastVehicleController3::DynamicRayCastVehicleController3(
+  chassis : @dynamics.RigidBodyHandle,
+) -> DynamicRayCastVehicleController3 {
+  DynamicRayCastVehicleController3::new(chassis)
 }
 
 ///|

--- a/control/ray_cast_vehicle_controller3d_real.mbt
+++ b/control/ray_cast_vehicle_controller3d_real.mbt
@@ -152,10 +152,13 @@ pub struct DynamicRayCastVehicleController3DReal {
   index_up_axis : Int
   /// The chassis local forward direction (`0 = x, 1 = y, 2 = z`).
   index_forward_axis : Int
+}
 
-  fn new(
-    chassis : @dynamics.RigidBodyHandle,
-  ) -> DynamicRayCastVehicleController3DReal
+///|
+pub fn DynamicRayCastVehicleController3DReal::DynamicRayCastVehicleController3DReal(
+  chassis : @dynamics.RigidBodyHandle,
+) -> DynamicRayCastVehicleController3DReal {
+  DynamicRayCastVehicleController3DReal::new(chassis)
 }
 
 ///|

--- a/core/core.mbt
+++ b/core/core.mbt
@@ -112,8 +112,11 @@ fn max(a : Real, b : Real) -> Real {
 pub struct Vec2 {
   x : Real
   y : Real
+}
 
-  fn new(x : Real, y : Real) -> Vec2
+///|
+pub fn Vec2::Vec2(x : Real, y : Real) -> Vec2 {
+  Vec2::new(x, y)
 }
 
 ///|
@@ -257,8 +260,11 @@ pub fn rotation_from_angle(angle : Real) -> Rot2 {
 pub struct Isometry2 {
   translation : Vec2
   rotation : Rot2
+}
 
-  fn new(translation : Vec2, rotation : Rot2) -> Isometry2
+///|
+pub fn Isometry2::Isometry2(translation : Vec2, rotation : Rot2) -> Isometry2 {
+  Isometry2::new(translation, rotation)
 }
 
 ///|
@@ -302,8 +308,11 @@ pub fn Isometry2::transform_point(self : Isometry2, point : Vec2) -> Vec2 {
 pub struct Aabb {
   mins : Vec2
   maxs : Vec2
+}
 
-  fn new(mins : Vec2, maxs : Vec2) -> Aabb
+///|
+pub fn Aabb::Aabb(mins : Vec2, maxs : Vec2) -> Aabb {
+  Aabb::new(mins, maxs)
 }
 
 ///|
@@ -333,8 +342,11 @@ pub struct Vec3 {
   x : Real
   y : Real
   z : Real
+}
 
-  fn new(x : Real, y : Real, z : Real) -> Vec3
+///|
+pub fn Vec3::Vec3(x : Real, y : Real, z : Real) -> Vec3 {
+  Vec3::new(x, y, z)
 }
 
 ///|
@@ -403,8 +415,11 @@ pub struct Quat {
   y : Real
   z : Real
   w : Real
+}
 
-  fn new(x : Real, y : Real, z : Real, w : Real) -> Quat
+///|
+pub fn Quat::Quat(x : Real, y : Real, z : Real, w : Real) -> Quat {
+  Quat::new(x, y, z, w)
 }
 
 ///|
@@ -549,8 +564,11 @@ pub fn rotation_between(from : Vec3, to : Vec3) -> Quat {
 pub struct Isometry3 {
   translation : Vec3
   rotation : Quat
+}
 
-  fn new(translation : Vec3, rotation : Quat) -> Isometry3
+///|
+pub fn Isometry3::Isometry3(translation : Vec3, rotation : Quat) -> Isometry3 {
+  Isometry3::new(translation, rotation)
 }
 
 ///|
@@ -598,8 +616,11 @@ pub fn Isometry3::transform_point(self : Isometry3, point : Vec3) -> Vec3 {
 pub struct Aabb3 {
   mins : Vec3
   maxs : Vec3
+}
 
-  fn new(mins : Vec3, maxs : Vec3) -> Aabb3
+///|
+pub fn Aabb3::Aabb3(mins : Vec3, maxs : Vec3) -> Aabb3 {
+  Aabb3::new(mins, maxs)
 }
 
 ///|
@@ -684,8 +705,15 @@ pub struct MassProperties {
   inertia : Real
   inv_inertia : Real
   center_of_mass : Vec2
+}
 
-  fn new(mass : Real, inertia : Real, center_of_mass : Vec2) -> MassProperties
+///|
+pub fn MassProperties::MassProperties(
+  mass : Real,
+  inertia : Real,
+  center_of_mass : Vec2,
+) -> MassProperties {
+  MassProperties::new(mass, inertia, center_of_mass)
 }
 
 ///|

--- a/core/dmatrix.mbt
+++ b/core/dmatrix.mbt
@@ -21,8 +21,11 @@ pub struct DMatrix {
   rows : Int
   cols : Int
   data : Array[Real]
+}
 
-  fn new(rows : Int, cols : Int, init : Real) -> DMatrix
+///|
+pub fn DMatrix::DMatrix(rows : Int, cols : Int, init : Real) -> DMatrix {
+  DMatrix::new(rows, cols, init)
 }
 
 ///|

--- a/core/mat2.mbt
+++ b/core/mat2.mbt
@@ -18,8 +18,11 @@ pub struct Mat2 {
   m01 : Real
   m10 : Real
   m11 : Real
+}
 
-  fn new(m00 : Real, m01 : Real, m10 : Real, m11 : Real) -> Mat2
+///|
+pub fn Mat2::Mat2(m00 : Real, m01 : Real, m10 : Real, m11 : Real) -> Mat2 {
+  Mat2::new(m00, m01, m10, m11)
 }
 
 ///|

--- a/core/mat3.mbt
+++ b/core/mat3.mbt
@@ -24,18 +24,21 @@ pub struct Mat3 {
   m20 : Real
   m21 : Real
   m22 : Real
+}
 
-  fn new(
-    m00 : Real,
-    m01 : Real,
-    m02 : Real,
-    m10 : Real,
-    m11 : Real,
-    m12 : Real,
-    m20 : Real,
-    m21 : Real,
-    m22 : Real,
-  ) -> Mat3
+///|
+pub fn Mat3::Mat3(
+  m00 : Real,
+  m01 : Real,
+  m02 : Real,
+  m10 : Real,
+  m11 : Real,
+  m12 : Real,
+  m20 : Real,
+  m21 : Real,
+  m22 : Real,
+) -> Mat3 {
+  Mat3::new(m00, m01, m02, m10, m11, m12, m20, m21, m22)
 }
 
 ///|
@@ -191,15 +194,18 @@ pub struct SdpMat3 {
   m22 : Real
   m23 : Real
   m33 : Real
+}
 
-  fn new(
-    m11 : Real,
-    m12 : Real,
-    m13 : Real,
-    m22 : Real,
-    m23 : Real,
-    m33 : Real,
-  ) -> SdpMat3
+///|
+pub fn SdpMat3::SdpMat3(
+  m11 : Real,
+  m12 : Real,
+  m13 : Real,
+  m22 : Real,
+  m23 : Real,
+  m33 : Real,
+) -> SdpMat3 {
+  SdpMat3::new(m11, m12, m13, m22, m23, m33)
 }
 
 ///|
@@ -278,12 +284,15 @@ pub struct MassProperties3 {
   inertia : SdpMat3
   inv_inertia : SdpMat3
   center_of_mass : Vec3
+}
 
-  fn new(
-    mass : Real,
-    inertia : SdpMat3,
-    center_of_mass : Vec3,
-  ) -> MassProperties3
+///|
+pub fn MassProperties3::MassProperties3(
+  mass : Real,
+  inertia : SdpMat3,
+  center_of_mass : Vec3,
+) -> MassProperties3 {
+  MassProperties3::new(mass, inertia, center_of_mass)
 }
 
 ///|

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -48,9 +48,8 @@ pub fn two_pi() -> Float
 pub struct Aabb {
   mins : Vec2
   maxs : Vec2
-
-  fn new(Vec2, Vec2) -> Aabb
 }
+pub fn Aabb::Aabb(Vec2, Vec2) -> Self
 pub fn Aabb::combine(Self, Self) -> Self
 pub fn Aabb::contains_point(Self, Vec2) -> Bool
 pub fn Aabb::from_points(Vec2, Vec2) -> Self
@@ -60,9 +59,8 @@ pub fn Aabb::new(Vec2, Vec2) -> Self
 pub struct Aabb3 {
   mins : Vec3
   maxs : Vec3
-
-  fn new(Vec3, Vec3) -> Aabb3
 }
+pub fn Aabb3::Aabb3(Vec3, Vec3) -> Self
 pub fn Aabb3::combine(Self, Self) -> Self
 pub fn Aabb3::dilated(Self, Float) -> Self
 pub fn Aabb3::from_points(Vec3, Vec3) -> Self
@@ -77,9 +75,8 @@ pub struct DMatrix {
   rows : Int
   cols : Int
   data : Array[Float]
-
-  fn new(Int, Int, Float) -> DMatrix
 }
+pub fn DMatrix::DMatrix(Int, Int, Float) -> Self
 pub fn DMatrix::cols(Self) -> Int
 pub fn DMatrix::get(Self, Int, Int) -> Float?
 pub fn DMatrix::identity(Int) -> Self
@@ -92,9 +89,8 @@ pub fn DMatrix::zeros(Int, Int) -> Self
 pub struct Isometry2 {
   translation : Vec2
   rotation : Rot2
-
-  fn new(Vec2, Rot2) -> Isometry2
 }
+pub fn Isometry2::Isometry2(Vec2, Rot2) -> Self
 pub fn Isometry2::from_translation(Vec2) -> Self
 pub fn Isometry2::identity() -> Self
 pub fn Isometry2::inverse(Self) -> Self
@@ -106,9 +102,8 @@ pub fn Isometry2::transform_point(Self, Vec2) -> Vec2
 pub struct Isometry3 {
   translation : Vec3
   rotation : Quat
-
-  fn new(Vec3, Quat) -> Isometry3
 }
+pub fn Isometry3::Isometry3(Vec3, Quat) -> Self
 pub fn Isometry3::from_translation(Vec3) -> Self
 pub fn Isometry3::identity() -> Self
 pub fn Isometry3::inverse(Self) -> Self
@@ -122,9 +117,8 @@ pub struct MassProperties {
   inertia : Float
   inv_inertia : Float
   center_of_mass : Vec2
-
-  fn new(Float, Float, Vec2) -> MassProperties
 }
+pub fn MassProperties::MassProperties(Float, Float, Vec2) -> Self
 pub fn MassProperties::add(Self, Self) -> Self
 pub fn MassProperties::default() -> Self
 pub fn MassProperties::new(Float, Float, Vec2) -> Self
@@ -137,9 +131,8 @@ pub struct MassProperties3 {
   inertia : SdpMat3
   inv_inertia : SdpMat3
   center_of_mass : Vec3
-
-  fn new(Float, SdpMat3, Vec3) -> MassProperties3
 }
+pub fn MassProperties3::MassProperties3(Float, SdpMat3, Vec3) -> Self
 pub fn MassProperties3::add(Self, Self) -> Self
 pub fn MassProperties3::default() -> Self
 pub fn MassProperties3::new(Float, SdpMat3, Vec3) -> Self
@@ -152,9 +145,8 @@ pub struct Mat2 {
   m01 : Float
   m10 : Float
   m11 : Float
-
-  fn new(Float, Float, Float, Float) -> Mat2
 }
+pub fn Mat2::Mat2(Float, Float, Float, Float) -> Self
 pub fn Mat2::add(Self, Self) -> Self
 pub fn Mat2::determinant(Self) -> Float
 pub fn Mat2::identity() -> Self
@@ -177,9 +169,8 @@ pub struct Mat3 {
   m20 : Float
   m21 : Float
   m22 : Float
-
-  fn new(Float, Float, Float, Float, Float, Float, Float, Float, Float) -> Mat3
 }
+pub fn Mat3::Mat3(Float, Float, Float, Float, Float, Float, Float, Float, Float) -> Self
 pub fn Mat3::add(Self, Self) -> Self
 pub fn Mat3::determinant(Self) -> Float
 pub fn Mat3::from_diagonal(Vec3) -> Self
@@ -199,9 +190,8 @@ pub struct Quat {
   y : Float
   z : Float
   w : Float
-
-  fn new(Float, Float, Float, Float) -> Quat
 }
+pub fn Quat::Quat(Float, Float, Float, Float) -> Self
 pub fn Quat::conjugate(Self) -> Self
 pub fn Quat::dot(Self, Self) -> Float
 pub fn Quat::identity() -> Self
@@ -237,9 +227,8 @@ pub struct SdpMat3 {
   m22 : Float
   m23 : Float
   m33 : Float
-
-  fn new(Float, Float, Float, Float, Float, Float) -> SdpMat3
 }
+pub fn SdpMat3::SdpMat3(Float, Float, Float, Float, Float, Float) -> Self
 pub fn SdpMat3::from_diagonal(Vec3) -> Self
 pub fn SdpMat3::into_mat3(Self) -> Mat3
 pub fn SdpMat3::inverse(Self) -> Self
@@ -267,9 +256,8 @@ pub fn UserData128::zero() -> Self
 pub struct Vec2 {
   x : Float
   y : Float
-
-  fn new(Float, Float) -> Vec2
 }
+pub fn Vec2::Vec2(Float, Float) -> Self
 pub fn Vec2::add(Self, Self) -> Self
 pub fn Vec2::cross(Self, Self) -> Float
 pub fn Vec2::dot(Self, Self) -> Float
@@ -287,9 +275,8 @@ pub struct Vec3 {
   x : Float
   y : Float
   z : Float
-
-  fn new(Float, Float, Float) -> Vec3
 }
+pub fn Vec3::Vec3(Float, Float, Float) -> Self
 pub fn Vec3::add(Self, Self) -> Self
 pub fn Vec3::cross(Self, Self) -> Self
 pub fn Vec3::dot(Self, Self) -> Float

--- a/counters/ccd_counters.mbt
+++ b/counters/ccd_counters.mbt
@@ -19,8 +19,11 @@ pub struct CCDCounters {
   solver_time : Timer
   broad_phase_time : Timer
   narrow_phase_time : Timer
+}
 
-  fn new() -> CCDCounters
+///|
+pub fn CCDCounters::CCDCounters() -> CCDCounters {
+  CCDCounters::new()
 }
 
 ///|

--- a/counters/collision_detection_counters.mbt
+++ b/counters/collision_detection_counters.mbt
@@ -18,8 +18,11 @@ pub struct CollisionDetectionCounters {
   broad_phase_time : Timer
   final_broad_phase_time : Timer
   narrow_phase_time : Timer
+}
 
-  fn new() -> CollisionDetectionCounters
+///|
+pub fn CollisionDetectionCounters::CollisionDetectionCounters() -> CollisionDetectionCounters {
+  CollisionDetectionCounters::new()
 }
 
 ///|

--- a/counters/counters.mbt
+++ b/counters/counters.mbt
@@ -21,8 +21,11 @@ pub struct Counters {
   cd : CollisionDetectionCounters
   solver : SolverCounters
   ccd : CCDCounters
+}
 
-  fn new(enabled : Bool) -> Counters
+///|
+pub fn Counters::Counters(enabled : Bool) -> Counters {
+  Counters::new(enabled)
 }
 
 ///|

--- a/counters/pkg.generated.mbti
+++ b/counters/pkg.generated.mbti
@@ -12,9 +12,8 @@ pub struct CCDCounters {
   solver_time : Timer
   broad_phase_time : Timer
   narrow_phase_time : Timer
-
-  fn new() -> CCDCounters
 }
+pub fn CCDCounters::CCDCounters() -> Self
 pub fn CCDCounters::new() -> Self
 pub fn CCDCounters::num_substeps(Self) -> Int
 pub fn CCDCounters::reset(Self) -> Unit
@@ -26,9 +25,8 @@ pub struct CollisionDetectionCounters {
   broad_phase_time : Timer
   final_broad_phase_time : Timer
   narrow_phase_time : Timer
-
-  fn new() -> CollisionDetectionCounters
 }
+pub fn CollisionDetectionCounters::CollisionDetectionCounters() -> Self
 pub fn CollisionDetectionCounters::ncontact_pairs(Self) -> Int
 pub fn CollisionDetectionCounters::new() -> Self
 pub fn CollisionDetectionCounters::reset(Self) -> Unit
@@ -43,9 +41,8 @@ pub struct Counters {
   cd : CollisionDetectionCounters
   solver : SolverCounters
   ccd : CCDCounters
-
-  fn new(Bool) -> Counters
 }
+pub fn Counters::Counters(Bool) -> Self
 pub fn Counters::assembly_completed(Self) -> Unit
 pub fn Counters::assembly_started(Self) -> Unit
 pub fn Counters::assembly_time_ms(Self) -> Double
@@ -103,9 +100,8 @@ pub struct SolverCounters {
   velocity_assembly_time_constraints_init : Timer
   velocity_update_time : Timer
   velocity_writeback_time : Timer
-
-  fn new() -> SolverCounters
 }
+pub fn SolverCounters::SolverCounters() -> Self
 pub fn SolverCounters::nconstraints(Self) -> Int
 pub fn SolverCounters::ncontacts(Self) -> Int
 pub fn SolverCounters::new() -> Self
@@ -122,18 +118,16 @@ pub struct StagesCounters {
   solver_time : Timer
   ccd_time : Timer
   user_changes : Timer
-
-  fn new() -> StagesCounters
 }
+pub fn StagesCounters::StagesCounters() -> Self
 pub fn StagesCounters::new() -> Self
 pub fn StagesCounters::reset(Self) -> Unit
 pub fn StagesCounters::to_string(Self) -> String
 
 pub struct Timer {
   mut time_ms : Double
-
-  fn new() -> Timer
 }
+pub fn Timer::Timer() -> Self
 pub fn Timer::new() -> Self
 pub fn Timer::pause(Self) -> Unit
 pub fn Timer::reset(Self) -> Unit

--- a/counters/solver_counters.mbt
+++ b/counters/solver_counters.mbt
@@ -22,8 +22,11 @@ pub struct SolverCounters {
   velocity_assembly_time_constraints_init : Timer
   velocity_update_time : Timer
   velocity_writeback_time : Timer
+}
 
-  fn new() -> SolverCounters
+///|
+pub fn SolverCounters::SolverCounters() -> SolverCounters {
+  SolverCounters::new()
 }
 
 ///|

--- a/counters/stages_counters.mbt
+++ b/counters/stages_counters.mbt
@@ -21,8 +21,11 @@ pub struct StagesCounters {
   solver_time : Timer
   ccd_time : Timer
   user_changes : Timer
+}
 
-  fn new() -> StagesCounters
+///|
+pub fn StagesCounters::StagesCounters() -> StagesCounters {
+  StagesCounters::new()
 }
 
 ///|

--- a/counters/timer.mbt
+++ b/counters/timer.mbt
@@ -17,8 +17,11 @@ pub struct Timer {
   // In rapier, the timer only measures when the `profiler` feature is enabled.
   // This port keeps timers deterministic by default (always 0 unless a future profiler is added).
   mut time_ms : Double
+}
 
-  fn new() -> Timer
+///|
+pub fn Timer::Timer() -> Timer {
+  Timer::new()
 }
 
 ///|

--- a/data/arena.mbt
+++ b/data/arena.mbt
@@ -48,8 +48,11 @@ pub struct Arena[T] {
   mut generation : Int
   mut free_list_head : Int?
   mut len : Int
+}
 
-  fn[T] new() -> Arena[T]
+///|
+pub fn[T] Arena::Arena() -> Arena[T] {
+  Arena::new()
 }
 
 ///|

--- a/data/arena_test.mbt
+++ b/data/arena_test.mbt
@@ -56,7 +56,7 @@ test "arena drain removes all occupied elements" {
     }
   }
   got.sort()
-  inspect(got, content="[\"hello\", \"world\"]")
+  debug_inspect(got, content="[\"hello\", \"world\"]")
   inspect(arena.get(idx1) is None, content="true")
   inspect(arena.get(idx2) is None, content="true")
   inspect(arena.capacity() == 0, content="true")

--- a/data/coarena.mbt
+++ b/data/coarena.mbt
@@ -15,8 +15,11 @@
 ///|
 pub struct Coarena[T] {
   data : Array[(Int, T)]
+}
 
-  fn[T] new() -> Coarena[T]
+///|
+pub fn[T] Coarena::Coarena() -> Coarena[T] {
+  Coarena::new()
 }
 
 ///|

--- a/data/graph.mbt
+++ b/data/graph.mbt
@@ -22,8 +22,11 @@
 ///|
 pub struct NodeIndex {
   index : Int
+}
 
-  fn new(x : Int) -> NodeIndex
+///|
+pub fn NodeIndex::NodeIndex(x : Int) -> NodeIndex {
+  NodeIndex::new(x)
 }
 
 ///|
@@ -44,8 +47,11 @@ pub fn NodeIndex::end() -> NodeIndex {
 ///|
 pub struct EdgeIndex {
   index : Int
+}
 
-  fn new(x : Int) -> EdgeIndex
+///|
+pub fn EdgeIndex::EdgeIndex(x : Int) -> EdgeIndex {
+  EdgeIndex::new(x)
 }
 
 ///|

--- a/data/modified_objects.mbt
+++ b/data/modified_objects.mbt
@@ -16,8 +16,14 @@
 pub struct ModifiedObjects[Handle, Object] {
   handles : Array[Handle]
   object_marker : Object?
+}
 
-  fn[Handle, Object] new() -> ModifiedObjects[Handle, Object]
+///|
+pub fn[Handle, Object] ModifiedObjects::ModifiedObjects() -> ModifiedObjects[
+  Handle,
+  Object,
+] {
+  ModifiedObjects::new()
 }
 
 ///|

--- a/data/pkg.generated.mbti
+++ b/data/pkg.generated.mbti
@@ -11,9 +11,8 @@ pub struct Arena[T] {
   mut generation : Int
   mut free_list_head : Int?
   mut len : Int
-
-  fn[T] new() -> Arena[T]
 }
+pub fn[T] Arena::Arena() -> Self[T]
 pub fn[T] Arena::capacity(Self[T]) -> Int
 pub fn[T] Arena::clear(Self[T]) -> Unit
 pub fn[T] Arena::contains(Self[T], Index) -> Bool
@@ -39,9 +38,8 @@ pub fn[T] Arena::with_capacity(Int) -> Self[T]
 
 pub struct Coarena[T] {
   data : Array[(Int, T)]
-
-  fn[T] new() -> Coarena[T]
 }
+pub fn[T] Coarena::Coarena() -> Self[T]
 pub fn[T] Coarena::ensure_element_exist(Self[T], Index, T) -> T
 pub fn[T] Coarena::ensure_pair_exists(Self[T], Index, Index, T) -> (T, T)
 pub fn[T] Coarena::get(Self[T], Index) -> T?
@@ -81,9 +79,8 @@ pub fn[E] Edge::target(Self[E]) -> NodeIndex
 
 pub struct EdgeIndex {
   index : Int
-
-  fn new(Int) -> EdgeIndex
 }
+pub fn EdgeIndex::EdgeIndex(Int) -> Self
 pub fn EdgeIndex::end() -> Self
 pub fn EdgeIndex::index(Self) -> Int
 pub fn EdgeIndex::new(Int) -> Self
@@ -168,9 +165,8 @@ pub fn[T] IterMut::next(Self[T]) -> (Index, T)?
 pub struct ModifiedObjects[Handle, Object] {
   handles : Array[Handle]
   object_marker : Object?
-
-  fn[Handle, Object] new() -> ModifiedObjects[Handle, Object]
 }
+pub fn[Handle, Object] ModifiedObjects::ModifiedObjects() -> Self[Handle, Object]
 pub fn[Handle, Object] ModifiedObjects::as_internal(Self[Handle, Object]) -> Array[Handle]
 pub fn[Handle, Object] ModifiedObjects::as_mut_internal(Self[Handle, Object]) -> Array[Handle]
 pub fn[Handle, Object] ModifiedObjects::clear(Self[Handle, Object]) -> Unit
@@ -187,9 +183,8 @@ pub struct Node[N] {
 
 pub struct NodeIndex {
   index : Int
-
-  fn new(Int) -> NodeIndex
 }
+pub fn NodeIndex::NodeIndex(Int) -> Self
 pub fn NodeIndex::end() -> Self
 pub fn NodeIndex::index(Self) -> Int
 pub fn NodeIndex::new(Int) -> Self
@@ -200,9 +195,8 @@ pub struct PubSub[T] {
   messages : Array[T]
   offsets : Array[Int]
   cursors : Array[PubSubCursor]
-
-  fn[T] new() -> PubSub[T]
 }
+pub fn[T] PubSub::PubSub() -> Self[T]
 pub fn[T] PubSub::ack(Self[T], Subscription[T]) -> Unit
 pub fn[T] PubSub::new() -> Self[T]
 pub fn[T] PubSub::publish(Self[T], T) -> Unit

--- a/data/pubsub.mbt
+++ b/data/pubsub.mbt
@@ -33,8 +33,11 @@ pub struct PubSub[T] {
   messages : Array[T]
   offsets : Array[Int]
   cursors : Array[PubSubCursor]
+}
 
-  fn[T] new() -> PubSub[T]
+///|
+pub fn[T] PubSub::PubSub() -> PubSub[T] {
+  PubSub::new()
 }
 
 ///|

--- a/docs/testing/parity_workflow_2d_3d.md
+++ b/docs/testing/parity_workflow_2d_3d.md
@@ -25,8 +25,8 @@ The gate enforces all of the following in one run:
 2. `python3 tools/rapier_pub_style_audit.py run`
    - requires style class `renamed=0`.
 3. Representative parity tests:
-   - `moon test --frozen -p Milky2018/moon_rapier/rapier_full_parity -f examples2d_parity_test.mbt`
-   - `moon test --frozen -p Milky2018/moon_rapier/rapier_full_parity -f examples3d_parity_test.mbt`
+   - `moon test --frozen rapier_full_parity/examples2d_parity_test.mbt`
+   - `moon test --frozen rapier_full_parity/examples3d_basics_parity_test.mbt`
 
 ## CI Integration
 

--- a/dynamics/axes_mask.mbt
+++ b/dynamics/axes_mask.mbt
@@ -15,8 +15,11 @@
 ///|
 pub struct AxesMask {
   bits : Int
+}
 
-  fn new(bits : Int) -> AxesMask
+///|
+pub fn AxesMask::AxesMask(bits : Int) -> AxesMask {
+  AxesMask::new(bits)
 }
 
 ///|

--- a/dynamics/integration_parameters.mbt
+++ b/dynamics/integration_parameters.mbt
@@ -16,11 +16,14 @@
 pub struct SpringCoefficients {
   natural_frequency : @core.Real
   damping_ratio : @core.Real
+}
 
-  fn new(
-    natural_frequency : @core.Real,
-    damping_ratio : @core.Real,
-  ) -> SpringCoefficients
+///|
+pub fn SpringCoefficients::SpringCoefficients(
+  natural_frequency : @core.Real,
+  damping_ratio : @core.Real,
+) -> SpringCoefficients {
+  SpringCoefficients::new(natural_frequency, damping_ratio)
 }
 
 ///|
@@ -138,8 +141,11 @@ pub struct IntegrationParameters {
   mut min_island_size : Int
   mut max_ccd_substeps : Int
   friction_model : FrictionModel
+}
 
-  fn new() -> IntegrationParameters
+///|
+pub fn IntegrationParameters::IntegrationParameters() -> IntegrationParameters {
+  IntegrationParameters::new()
 }
 
 ///|

--- a/dynamics/interaction_groups.mbt
+++ b/dynamics/interaction_groups.mbt
@@ -15,8 +15,11 @@
 ///|
 pub struct Group {
   value : Int
+}
 
-  fn new(bits : Int) -> Group
+///|
+pub fn Group::Group(bits : Int) -> Group {
+  Group::new(bits)
 }
 
 ///|
@@ -219,12 +222,15 @@ pub struct InteractionGroups {
   mut memberships : Group
   mut filter : Group
   test_mode : InteractionTestMode
+}
 
-  fn new(
-    memberships : Group,
-    filter : Group,
-    test_mode : InteractionTestMode,
-  ) -> InteractionGroups
+///|
+pub fn InteractionGroups::InteractionGroups(
+  memberships : Group,
+  filter : Group,
+  test_mode : InteractionTestMode,
+) -> InteractionGroups {
+  InteractionGroups::new(memberships, filter, test_mode)
 }
 
 ///|

--- a/dynamics/island_manager3d.mbt
+++ b/dynamics/island_manager3d.mbt
@@ -102,8 +102,11 @@ pub struct IslandManager3D {
   stack : Array[RigidBodyHandle]
   optimizer : IslandsOptimizer3D
   mut traversal_timestamp : Int
+}
 
-  fn new() -> IslandManager3D
+///|
+pub fn IslandManager3D::IslandManager3D() -> IslandManager3D {
+  IslandManager3D::new()
 }
 
 ///|

--- a/dynamics/joint_builders.mbt
+++ b/dynamics/joint_builders.mbt
@@ -73,8 +73,13 @@ pub struct RopeJointBuilder {
   mut softness : SpringCoefficients
   mut motor : JointMotor
   mut motor_enabled : Bool
+}
 
-  fn new(max_length : @core.Real) -> RopeJointBuilder
+///|
+pub fn RopeJointBuilder::RopeJointBuilder(
+  max_length : @core.Real,
+) -> RopeJointBuilder {
+  RopeJointBuilder::new(max_length)
 }
 
 ///|
@@ -294,8 +299,13 @@ pub struct PinSlotJointBuilder {
   mut local_anchor2 : @core.Vec2
   mut limits : JointLimits
   mut limits_enabled : Bool
+}
 
-  fn new(axis : @core.Vec2) -> PinSlotJointBuilder
+///|
+pub fn PinSlotJointBuilder::PinSlotJointBuilder(
+  axis : @core.Vec2,
+) -> PinSlotJointBuilder {
+  PinSlotJointBuilder::new(axis)
 }
 
 ///|

--- a/dynamics/joint_builders3d_real.mbt
+++ b/dynamics/joint_builders3d_real.mbt
@@ -51,8 +51,13 @@ pub struct GenericJoint3DRealBuilder {
   mut local_basis2 : @core.Quat
   axis_states : Array[AxisState3DReal]
   motors : Array[MotorState3DReal]
+}
 
-  fn new(locked_axes : JointAxesMask3DReal) -> GenericJoint3DRealBuilder
+///|
+pub fn GenericJoint3DRealBuilder::GenericJoint3DRealBuilder(
+  locked_axes : JointAxesMask3DReal,
+) -> GenericJoint3DRealBuilder {
+  GenericJoint3DRealBuilder::new(locked_axes)
 }
 
 ///|

--- a/dynamics/joint_set3d_real.mbt
+++ b/dynamics/joint_set3d_real.mbt
@@ -233,8 +233,11 @@ pub struct JointSet3DReal {
   generic_motor_impulses : Array[Array[@core.Real]]
   generic_coupled_impulses : Array[@core.Real]
   spring_impulses : Array[@core.Real]
+}
 
-  fn new() -> JointSet3DReal
+///|
+pub fn JointSet3DReal::JointSet3DReal() -> JointSet3DReal {
+  JointSet3DReal::new()
 }
 
 ///|

--- a/dynamics/joint_types.mbt
+++ b/dynamics/joint_types.mbt
@@ -28,8 +28,11 @@ pub(all) enum JointAxis {
 ///|
 pub struct JointAxesMask {
   bits : Int
+}
 
-  fn new(bits : Int) -> JointAxesMask
+///|
+pub fn JointAxesMask::JointAxesMask(bits : Int) -> JointAxesMask {
+  JointAxesMask::new(bits)
 }
 
 ///|
@@ -213,8 +216,14 @@ pub struct JointLimits {
   min : @core.Real
   max : @core.Real
   mut impulse : @core.Real
+}
 
-  fn new(min : @core.Real, max : @core.Real) -> JointLimits
+///|
+pub fn JointLimits::JointLimits(
+  min : @core.Real,
+  max : @core.Real,
+) -> JointLimits {
+  JointLimits::new(min, max)
 }
 
 ///|

--- a/dynamics/joint_types3d_real.mbt
+++ b/dynamics/joint_types3d_real.mbt
@@ -28,8 +28,13 @@ pub(all) enum JointAxis3DReal {
 ///|
 pub struct JointAxesMask3DReal {
   bits : Int
+}
 
-  fn new(bits : Int) -> JointAxesMask3DReal
+///|
+pub fn JointAxesMask3DReal::JointAxesMask3DReal(
+  bits : Int,
+) -> JointAxesMask3DReal {
+  JointAxesMask3DReal::new(bits)
 }
 
 ///|

--- a/dynamics/joint_wrappers3d_real.mbt
+++ b/dynamics/joint_wrappers3d_real.mbt
@@ -24,8 +24,13 @@
 ///|
 pub struct RevoluteJoint3DRealBuilder {
   inner : GenericJoint3DRealBuilder
+}
 
-  fn new(axis : @core.Vec3) -> RevoluteJoint3DRealBuilder
+///|
+pub fn RevoluteJoint3DRealBuilder::RevoluteJoint3DRealBuilder(
+  axis : @core.Vec3,
+) -> RevoluteJoint3DRealBuilder {
+  RevoluteJoint3DRealBuilder::new(axis)
 }
 
 ///|
@@ -112,8 +117,13 @@ pub fn RevoluteJoint3DRealBuilder::build(
 ///|
 pub struct PrismaticJoint3DRealBuilder {
   inner : GenericJoint3DRealBuilder
+}
 
-  fn new(axis : @core.Vec3) -> PrismaticJoint3DRealBuilder
+///|
+pub fn PrismaticJoint3DRealBuilder::PrismaticJoint3DRealBuilder(
+  axis : @core.Vec3,
+) -> PrismaticJoint3DRealBuilder {
+  PrismaticJoint3DRealBuilder::new(axis)
 }
 
 ///|
@@ -200,8 +210,11 @@ pub fn PrismaticJoint3DRealBuilder::build(
 ///|
 pub struct FixedJoint3DRealBuilder {
   inner : GenericJoint3DRealBuilder
+}
 
-  fn new() -> FixedJoint3DRealBuilder
+///|
+pub fn FixedJoint3DRealBuilder::FixedJoint3DRealBuilder() -> FixedJoint3DRealBuilder {
+  FixedJoint3DRealBuilder::new()
 }
 
 ///|
@@ -251,8 +264,11 @@ pub fn FixedJoint3DRealBuilder::build(
 ///|
 pub struct SphericalJoint3DRealBuilder {
   inner : GenericJoint3DRealBuilder
+}
 
-  fn new() -> SphericalJoint3DRealBuilder
+///|
+pub fn SphericalJoint3DRealBuilder::SphericalJoint3DRealBuilder() -> SphericalJoint3DRealBuilder {
+  SphericalJoint3DRealBuilder::new()
 }
 
 ///|

--- a/dynamics/joints3.mbt
+++ b/dynamics/joints3.mbt
@@ -2770,8 +2770,11 @@ pub fn Multibody3DReal::inverse_kinematics(
 ///|
 pub struct MultibodyJointSet3DReal {
   inner : MultibodyJointSet3
+}
 
-  fn new() -> MultibodyJointSet3DReal
+///|
+pub fn MultibodyJointSet3DReal::MultibodyJointSet3DReal() -> MultibodyJointSet3DReal {
+  MultibodyJointSet3DReal::new()
 }
 
 ///|

--- a/dynamics/locked_axes.mbt
+++ b/dynamics/locked_axes.mbt
@@ -20,8 +20,11 @@
 /// so the public surface matches Rapier's default-feature crates.
 pub struct LockedAxes {
   bits : Int
+}
 
-  fn new(bits : Int) -> LockedAxes
+///|
+pub fn LockedAxes::LockedAxes(bits : Int) -> LockedAxes {
+  LockedAxes::new(bits)
 }
 
 ///|

--- a/dynamics/multibody.mbt
+++ b/dynamics/multibody.mbt
@@ -313,8 +313,6 @@ fn multibody_joint_with_local_displacements(
 ///|
 pub struct LinkId {
   value : Int
-
-  fn new(value : Int) -> LinkId
 }
 
 ///|

--- a/dynamics/multibody.mbt
+++ b/dynamics/multibody.mbt
@@ -1820,7 +1820,7 @@ fn MultibodyJointSet::find_graph_edge_by_child(
 fn mb_split_values(text : String, sep : String) -> Array[String] {
   let values : Array[String] = []
   for part in text.split(sep[:]) {
-    let value = part.to_string()
+    let value = part.to_owned()
     if value.length() > 0 {
       values.push(value)
     }
@@ -1886,7 +1886,7 @@ fn write_link(sb : StringBuilder, link : MultibodyLink) -> Unit {
 ///|
 fn parse_link(text : String) -> MultibodyLink? {
   if text.strip_prefix("L^"[:]) is Some(view) {
-    let fields = mb_split_values(view.to_string(), "^")
+    let fields = mb_split_values(view.to_owned(), "^")
     if fields.length() < 24 {
       return None
     }
@@ -2074,10 +2074,10 @@ pub fn MultibodyJointSet::serialize(self : MultibodyJointSet) -> String {
 pub fn MultibodyJointSet::deserialize(data : String) -> MultibodyJointSet {
   let set = MultibodyJointSet::new()
   if data.strip_prefix("mbs="[:]) is Some(view) {
-    let raw = view.to_string()
+    let raw = view.to_owned()
     if raw.length() > 0 {
       for mb_text in raw.split("@"[:]) {
-        let mb_str = mb_text.to_string()
+        let mb_str = mb_text.to_owned()
         if mb_str.length() == 0 {
           continue
         }

--- a/dynamics/pkg.generated.mbti
+++ b/dynamics/pkg.generated.mbti
@@ -15,9 +15,8 @@ pub fn unit_joint_motor_constraint(IntegrationParameters, Multibody, MultibodyLi
 // Types and methods
 pub struct AxesMask {
   bits : Int
-
-  fn new(Int) -> AxesMask
 }
+pub fn AxesMask::AxesMask(Int) -> Self
 pub fn AxesMask::all() -> Self
 pub fn AxesMask::ang_axes() -> Self
 pub fn AxesMask::ang_x() -> Self
@@ -43,9 +42,8 @@ pub(all) enum AxisState3DReal {
 pub struct BodyPair {
   body1 : RigidBodyHandle
   body2 : RigidBodyHandle
-
-  fn new(RigidBodyHandle, RigidBodyHandle) -> BodyPair
 }
+pub fn BodyPair::BodyPair(RigidBodyHandle, RigidBodyHandle) -> Self
 pub fn BodyPair::new(RigidBodyHandle, RigidBodyHandle) -> Self
 
 pub struct CCDSolver {
@@ -69,9 +67,8 @@ pub fn CoefficientCombineRule::combine(Float, Float, Self, Self) -> Float
 
 pub struct ContactGraph {
   pairs : Array[(RigidBodyHandle, RigidBodyHandle)]
-
-  fn new() -> ContactGraph
 }
+pub fn ContactGraph::ContactGraph() -> Self
 pub fn ContactGraph::add_pair(Self, RigidBodyHandle, RigidBodyHandle) -> Unit
 pub fn ContactGraph::clear(Self) -> Unit
 pub fn ContactGraph::new() -> Self
@@ -91,9 +88,8 @@ pub struct FixedJoint {
 
 pub struct FixedJoint3DRealBuilder {
   inner : GenericJoint3DRealBuilder
-
-  fn new() -> FixedJoint3DRealBuilder
 }
+pub fn FixedJoint3DRealBuilder::FixedJoint3DRealBuilder() -> Self
 pub fn FixedJoint3DRealBuilder::build(Self) -> GenericJoint3DReal
 pub fn FixedJoint3DRealBuilder::local_anchor1(Self, @core.Vec3) -> Self
 pub fn FixedJoint3DRealBuilder::local_anchor2(Self, @core.Vec3) -> Self
@@ -133,9 +129,8 @@ pub struct GenericJoint {
   mut contacts_enabled : Bool
   mut enabled : JointEnabled
   user_data : Int
-
-  fn new(JointAxesMask) -> GenericJoint
 }
+pub fn GenericJoint::GenericJoint(JointAxesMask) -> Self
 pub fn GenericJoint::as_fixed(Self) -> Self?
 pub fn GenericJoint::as_fixed_mut(Self) -> Self?
 pub fn GenericJoint::as_prismatic(Self) -> Self?
@@ -227,9 +222,8 @@ pub struct GenericJoint3DRealBuilder {
   mut local_basis2 : @core.Quat
   axis_states : Array[AxisState3DReal]
   motors : Array[MotorState3DReal]
-
-  fn new(JointAxesMask3DReal) -> GenericJoint3DRealBuilder
 }
+pub fn GenericJoint3DRealBuilder::GenericJoint3DRealBuilder(JointAxesMask3DReal) -> Self
 pub fn GenericJoint3DRealBuilder::build(Self) -> GenericJoint3DReal
 pub fn GenericJoint3DRealBuilder::contacts_enabled(Self, Bool) -> Self
 pub fn GenericJoint3DRealBuilder::coupled_axes(Self, JointAxesMask3DReal) -> Self
@@ -274,9 +268,8 @@ pub struct GenericJointConstraint3DReal {
 
 pub struct Group {
   value : Int
-
-  fn new(Int) -> Group
 }
+pub fn Group::Group(Int) -> Self
 pub fn Group::all() -> Self
 pub fn Group::bits(Self) -> Int
 pub fn Group::equals(Self, Self) -> Bool
@@ -339,8 +332,6 @@ pub fn ImpulseJointGraph::nodes(Self) -> Array[RigidBodyHandle]
 pub struct ImpulseJointHandle {
   id : Int
   generation : Int
-
-  fn new(Int, Int) -> ImpulseJointHandle
 }
 pub fn ImpulseJointHandle::from_raw_parts(Int, Int) -> Self
 pub fn ImpulseJointHandle::into_raw_parts(Self) -> (Int, Int)
@@ -425,9 +416,8 @@ pub struct IntegrationParameters {
   mut min_island_size : Int
   mut max_ccd_substeps : Int
   friction_model : FrictionModel
-
-  fn new() -> IntegrationParameters
 }
+pub fn IntegrationParameters::IntegrationParameters() -> Self
 pub fn IntegrationParameters::allowed_linear_error(Self) -> Float
 pub fn IntegrationParameters::default() -> Self
 pub fn IntegrationParameters::inv_dt(Self) -> Float
@@ -454,9 +444,8 @@ pub struct InteractionGroups {
   mut memberships : Group
   mut filter : Group
   test_mode : InteractionTestMode
-
-  fn new(Group, Group, InteractionTestMode) -> InteractionGroups
 }
+pub fn InteractionGroups::InteractionGroups(Group, Group, InteractionTestMode) -> Self
 pub fn InteractionGroups::all() -> Self
 pub fn InteractionGroups::default() -> Self
 pub fn InteractionGroups::filter(Self) -> Group
@@ -506,9 +495,8 @@ pub struct IslandManager {
   body_island_generations : Array[Int]
   body_island_indices : Array[Int]
   body_state_generations : Array[Int]
-
-  fn new() -> IslandManager
 }
+pub fn IslandManager::IslandManager() -> Self
 pub fn IslandManager::active_bodies(Self) -> Array[RigidBodyHandle]
 pub fn IslandManager::active_islands(Self) -> Array[Int]
 pub fn IslandManager::interaction_started_or_stopped(Self, RigidBodySet, RigidBodyHandle?, RigidBodyHandle?, Bool, Bool) -> Unit
@@ -522,9 +510,8 @@ pub fn IslandManager::wake_up(Self, RigidBodySet, RigidBodyHandle, Bool) -> Unit
 
 pub struct IslandManager3 {
   inner : IslandManager
-
-  fn new() -> IslandManager3
 }
+pub fn IslandManager3::IslandManager3() -> Self
 pub fn IslandManager3::active_bodies(Self) -> Array[RigidBodyHandle]
 pub fn IslandManager3::as_2d(Self) -> IslandManager
 pub fn IslandManager3::interaction_started_or_stopped(Self, RigidBodySet3, RigidBodyHandle?, RigidBodyHandle?, Bool, Bool) -> Unit
@@ -550,9 +537,8 @@ pub struct IslandManager3D {
   stack : Array[RigidBodyHandle]
   optimizer : IslandsOptimizer3D
   mut traversal_timestamp : Int
-
-  fn new() -> IslandManager3D
 }
+pub fn IslandManager3D::IslandManager3D() -> Self
 pub fn IslandManager3D::active_bodies(Self) -> Array[RigidBodyHandle]
 pub fn IslandManager3D::active_islands(Self) -> Array[Int]
 pub fn IslandManager3D::island_additional_solver_iterations(Self, Int) -> Int
@@ -581,9 +567,8 @@ pub fn Jacobian3::zeros(Int) -> Self
 
 pub struct JointAxesMask {
   bits : Int
-
-  fn new(Int) -> JointAxesMask
 }
+pub fn JointAxesMask::JointAxesMask(Int) -> Self
 pub fn JointAxesMask::all() -> Self
 pub fn JointAxesMask::all3() -> Self
 pub fn JointAxesMask::ang_axes() -> Self
@@ -619,9 +604,8 @@ pub fn JointAxesMask::or(Self, Self) -> Self
 
 pub struct JointAxesMask3DReal {
   bits : Int
-
-  fn new(Int) -> JointAxesMask3DReal
 }
+pub fn JointAxesMask3DReal::JointAxesMask3DReal(Int) -> Self
 pub fn JointAxesMask3DReal::all() -> Self
 pub fn JointAxesMask3DReal::ang_axes() -> Self
 pub fn JointAxesMask3DReal::ang_x() -> Self
@@ -678,9 +662,8 @@ pub struct JointLimits {
   min : Float
   max : Float
   mut impulse : Float
-
-  fn new(Float, Float) -> JointLimits
 }
+pub fn JointLimits::JointLimits(Float, Float) -> Self
 pub fn JointLimits::clear_impulse(Self) -> Self
 pub fn JointLimits::default() -> Self
 pub fn JointLimits::impulse(Self) -> Float
@@ -747,9 +730,8 @@ pub struct JointSet3DReal {
   generic_motor_impulses : Array[Array[Float]]
   generic_coupled_impulses : Array[Float]
   spring_impulses : Array[Float]
-
-  fn new() -> JointSet3DReal
 }
+pub fn JointSet3DReal::JointSet3DReal() -> Self
 pub fn JointSet3DReal::disabled_contact_pairs(Self) -> Array[(RigidBodyHandle, RigidBodyHandle)]
 pub fn JointSet3DReal::insert_generic(Self, RigidBodyHandle, RigidBodyHandle, GenericJoint3DReal, Bool) -> JointHandle3DReal
 pub fn JointSet3DReal::insert_prismatic_motor_position(Self, RigidBodyHandle, RigidBodyHandle, @core.Vec3, @core.Vec3, @core.Vec3, Float, Float, Float) -> Unit
@@ -774,8 +756,6 @@ pub fn JointSolverBody::invalid() -> Self
 
 pub struct LinkId {
   value : Int
-
-  fn new(Int) -> LinkId
 }
 
 pub(all) enum LinkOrBodyRef {
@@ -786,9 +766,8 @@ pub(all) enum LinkOrBodyRef {
 
 pub struct LockedAxes {
   bits : Int
-
-  fn new(Int) -> LockedAxes
 }
+pub fn LockedAxes::LockedAxes(Int) -> Self
 pub fn LockedAxes::bits(Self) -> Int
 pub fn LockedAxes::contains(Self, Self) -> Bool
 pub fn LockedAxes::empty() -> Self
@@ -957,9 +936,8 @@ pub fn MultibodyJointSet3::take_wake_up(Self) -> Array[RigidBodyHandle]
 
 pub struct MultibodyJointSet3DReal {
   inner : MultibodyJointSet3
-
-  fn new() -> MultibodyJointSet3DReal
 }
+pub fn MultibodyJointSet3DReal::MultibodyJointSet3DReal() -> Self
 pub fn MultibodyJointSet3DReal::attached_bodies(Self, RigidBodyHandle) -> Array[RigidBodyHandle]
 pub fn MultibodyJointSet3DReal::attached_joints(Self, RigidBodyHandle) -> Array[(RigidBodyHandle, RigidBodyHandle, MultibodyJointHandle)]
 pub fn MultibodyJointSet3DReal::bodies_attached_with_enabled_joint(Self, RigidBodyHandle) -> Array[RigidBodyHandle]
@@ -1027,9 +1005,8 @@ pub struct PinSlotJointBuilder {
   mut local_anchor2 : @core.Vec2
   mut limits : JointLimits
   mut limits_enabled : Bool
-
-  fn new(@core.Vec2) -> PinSlotJointBuilder
 }
+pub fn PinSlotJointBuilder::PinSlotJointBuilder(@core.Vec2) -> Self
 pub fn PinSlotJointBuilder::build(Self) -> PinSlotJoint
 pub fn PinSlotJointBuilder::limits(Self, Float, Float) -> Self
 pub fn PinSlotJointBuilder::local_anchor1(Self, @core.Vec2) -> Self
@@ -1077,9 +1054,8 @@ pub struct PrismaticJoint3DReal {
 
 pub struct PrismaticJoint3DRealBuilder {
   inner : GenericJoint3DRealBuilder
-
-  fn new(@core.Vec3) -> PrismaticJoint3DRealBuilder
 }
+pub fn PrismaticJoint3DRealBuilder::PrismaticJoint3DRealBuilder(@core.Vec3) -> Self
 pub fn PrismaticJoint3DRealBuilder::build(Self) -> GenericJoint3DReal
 pub fn PrismaticJoint3DRealBuilder::limits(Self, Float, Float) -> Self
 pub fn PrismaticJoint3DRealBuilder::local_anchor1(Self, @core.Vec3) -> Self
@@ -1106,9 +1082,8 @@ pub struct PrismaticJointBuilder3 {
   axis : @core.Vec3
   local_anchor1_3 : @core.Vec3
   local_anchor2_3 : @core.Vec3
-
-  fn new(@core.Vec3) -> PrismaticJointBuilder3
 }
+pub fn PrismaticJointBuilder3::PrismaticJointBuilder3(@core.Vec3) -> Self
 pub fn PrismaticJointBuilder3::build(Self) -> PrismaticJoint
 pub fn PrismaticJointBuilder3::limits(Self, Float, Float) -> Self
 pub fn PrismaticJointBuilder3::local_anchor1(Self, @core.Vec3) -> Self
@@ -1132,9 +1107,8 @@ pub struct RevoluteJoint3 {
   axis : @core.Vec3
   local_frame1_rotation : @core.Quat
   local_frame2_rotation : @core.Quat
-
-  fn new(@core.Vec3) -> RevoluteJoint3
 }
+pub fn RevoluteJoint3::RevoluteJoint3(@core.Vec3) -> Self
 pub fn RevoluteJoint3::angle(Self, @core.Quat, @core.Quat) -> Float
 pub fn RevoluteJoint3::new(@core.Vec3) -> Self
 
@@ -1144,9 +1118,8 @@ pub fn RevoluteJoint3Builder::new(@core.Vec3) -> Self
 
 pub struct RevoluteJoint3DRealBuilder {
   inner : GenericJoint3DRealBuilder
-
-  fn new(@core.Vec3) -> RevoluteJoint3DRealBuilder
 }
+pub fn RevoluteJoint3DRealBuilder::RevoluteJoint3DRealBuilder(@core.Vec3) -> Self
 pub fn RevoluteJoint3DRealBuilder::build(Self) -> GenericJoint3DReal
 pub fn RevoluteJoint3DRealBuilder::limits(Self, Float, Float) -> Self
 pub fn RevoluteJoint3DRealBuilder::local_anchor1(Self, @core.Vec3) -> Self
@@ -1173,9 +1146,8 @@ pub struct RevoluteJointBuilder3 {
   axis : @core.Vec3
   local_anchor1_3 : @core.Vec3
   local_anchor2_3 : @core.Vec3
-
-  fn new(@core.Vec3) -> RevoluteJointBuilder3
 }
+pub fn RevoluteJointBuilder3::RevoluteJointBuilder3(@core.Vec3) -> Self
 pub fn RevoluteJointBuilder3::build(Self) -> RevoluteJoint
 pub fn RevoluteJointBuilder3::limits(Self, Float, Float) -> Self
 pub fn RevoluteJointBuilder3::local_anchor1(Self, @core.Vec3) -> Self
@@ -1453,9 +1425,8 @@ pub struct RigidBodyBuilder {
   mut soft_ccd_prediction : Float
   mut dominance_group : Int
   mut user_data : @core.UserData128
-
-  fn new(RigidBodyType) -> RigidBodyBuilder
 }
+pub fn RigidBodyBuilder::RigidBodyBuilder(RigidBodyType) -> Self
 pub fn RigidBodyBuilder::additional_mass(Self, Float) -> Self
 pub fn RigidBodyBuilder::additional_mass_properties(Self, RigidBodyAdditionalMassProps) -> Self
 pub fn RigidBodyBuilder::additional_solver_iterations(Self, Int) -> Self
@@ -1586,9 +1557,8 @@ pub fn RigidBodyChanges::sleep_flag() -> Int
 
 pub struct RigidBodyColliders {
   mut colliders : Array[(Int, Int)]
-
-  fn new() -> RigidBodyColliders
 }
+pub fn RigidBodyColliders::RigidBodyColliders() -> Self
 pub fn RigidBodyColliders::attach_collider(Self, Int) -> Self
 pub fn RigidBodyColliders::attach_collider_raw(Self, Int, Int) -> Self
 pub fn RigidBodyColliders::detach_collider(Self, Int) -> Self
@@ -1605,9 +1575,8 @@ pub fn RigidBodyDamping::default() -> Self
 
 pub struct RigidBodyDominance {
   mut group : Int
-
-  fn new(Int) -> RigidBodyDominance
 }
+pub fn RigidBodyDominance::RigidBodyDominance(Int) -> Self
 pub fn RigidBodyDominance::default() -> Self
 pub fn RigidBodyDominance::effective_group(Self, RigidBodyType) -> Int
 pub fn RigidBodyDominance::new(Int) -> Self
@@ -1627,8 +1596,6 @@ pub fn RigidBodyForces::integrate(Self, Float, RigidBodyVelocity, RigidBodyMassP
 pub struct RigidBodyHandle {
   id : Int
   generation : Int
-
-  fn new(Int, Int) -> RigidBodyHandle
 }
 pub fn RigidBodyHandle::equals(Self, Self) -> Bool
 pub fn RigidBodyHandle::from_raw_parts(Int, Int) -> Self
@@ -1661,9 +1628,8 @@ pub fn RigidBodyMassProps::update_world_mass_properties(Self, RigidBodyType, @co
 pub struct RigidBodyPosition {
   mut position : @core.Isometry2
   mut next_position : @core.Isometry2
-
-  fn new(@core.Isometry2, @core.Isometry2) -> RigidBodyPosition
 }
+pub fn RigidBodyPosition::RigidBodyPosition(@core.Isometry2, @core.Isometry2) -> Self
 pub fn RigidBodyPosition::integrate_forces_and_velocities(Self, Float, RigidBodyForces, RigidBodyVelocity, RigidBodyMassProps) -> @core.Isometry2
 pub fn RigidBodyPosition::interpolate_velocity(Self, Float, @core.Vec2) -> RigidBodyVelocity
 pub fn RigidBodyPosition::new(@core.Isometry2, @core.Isometry2) -> Self
@@ -1671,9 +1637,8 @@ pub fn RigidBodyPosition::new(@core.Isometry2, @core.Isometry2) -> Self
 pub struct RigidBodyPosition3 {
   position : @core.Isometry3
   next_position : @core.Isometry3
-
-  fn new(@core.Isometry3, @core.Isometry3) -> RigidBodyPosition3
 }
+pub fn RigidBodyPosition3::RigidBodyPosition3(@core.Isometry3, @core.Isometry3) -> Self
 pub fn RigidBodyPosition3::interpolate_velocity(Self, Float, @core.Vec3) -> RigidBodyVelocity3
 pub fn RigidBodyPosition3::new(@core.Isometry3, @core.Isometry3) -> Self
 pub fn RigidBodyPosition3::pose_errors(Self, @core.Vec3) -> PdErrors3
@@ -1681,9 +1646,8 @@ pub fn RigidBodyPosition3::pose_errors(Self, @core.Vec3) -> PdErrors3
 pub struct RigidBodyPosition3D {
   position : @core.Isometry3
   next_position : @core.Isometry3
-
-  fn new(@core.Isometry3, @core.Isometry3) -> RigidBodyPosition3D
 }
+pub fn RigidBodyPosition3D::RigidBodyPosition3D(@core.Isometry3, @core.Isometry3) -> Self
 pub fn RigidBodyPosition3D::interpolate_velocity(Self, Float, @core.Vec3) -> RigidBodyVelocity3D
 pub fn RigidBodyPosition3D::new(@core.Isometry3, @core.Isometry3) -> Self
 
@@ -1693,9 +1657,8 @@ pub struct RigidBodySet {
   free_list : Array[Int]
   modified_bodies : Array[RigidBodyHandle]
   pending_collider_position_updates : Array[(Int, Int, @core.Isometry2)]
-
-  fn new() -> RigidBodySet
 }
+pub fn RigidBodySet::RigidBodySet() -> Self
 pub fn RigidBodySet::contains(Self, RigidBodyHandle) -> Bool
 pub fn RigidBodySet::deserialize(String) -> Self
 pub fn RigidBodySet::get(Self, RigidBodyHandle) -> RigidBody?
@@ -1720,9 +1683,8 @@ pub fn RigidBodySet::with_capacity(Int) -> Self
 
 pub struct RigidBodySet3 {
   inner : RigidBodySet
-
-  fn new() -> RigidBodySet3
 }
+pub fn RigidBodySet3::RigidBodySet3() -> Self
 pub fn RigidBodySet3::as_2d(Self) -> RigidBodySet
 pub fn RigidBodySet3::get(Self, RigidBodyHandle) -> RigidBody?
 pub fn RigidBodySet3::get_mut(Self, RigidBodyHandle) -> RigidBody?
@@ -1740,9 +1702,8 @@ pub struct RigidBodySet3D {
   bodies : Array[RigidBody3D?]
   generations : Array[Int]
   free_list : Array[Int]
-
-  fn new() -> RigidBodySet3D
 }
+pub fn RigidBodySet3D::RigidBodySet3D() -> Self
 pub fn RigidBodySet3D::advance_positions_all(Self, Float) -> Unit
 pub fn RigidBodySet3D::all_handles(Self) -> Array[RigidBodyHandle]
 pub fn RigidBodySet3D::apply_damping_all(Self, Float) -> Unit
@@ -1775,9 +1736,8 @@ pub fn RigidBodyType::is_kinematic(Self) -> Bool
 pub struct RigidBodyVelocity {
   mut linvel : @core.Vec2
   mut angvel : Float
-
-  fn new(@core.Vec2, Float) -> RigidBodyVelocity
 }
+pub fn RigidBodyVelocity::RigidBodyVelocity(@core.Vec2, Float) -> Self
 pub fn RigidBodyVelocity::angvel(Self) -> Float
 pub fn RigidBodyVelocity::apply_damping(Self, Float, RigidBodyDamping) -> Self
 pub fn RigidBodyVelocity::as_mut_slice(Self) -> Array[Float]
@@ -1844,9 +1804,8 @@ pub struct RopeJointBuilder {
   mut softness : SpringCoefficients
   mut motor : JointMotor
   mut motor_enabled : Bool
-
-  fn new(Float) -> RopeJointBuilder
 }
+pub fn RopeJointBuilder::RopeJointBuilder(Float) -> Self
 pub fn RopeJointBuilder::build(Self) -> RopeJoint
 pub fn RopeJointBuilder::local_anchor1(Self, @core.Vec2) -> Self
 pub fn RopeJointBuilder::local_anchor2(Self, @core.Vec2) -> Self
@@ -1862,9 +1821,8 @@ pub struct RopeJointBuilder3 {
   inner : RopeJointBuilder
   local_anchor1_3 : @core.Vec3
   local_anchor2_3 : @core.Vec3
-
-  fn new(Float) -> RopeJointBuilder3
 }
+pub fn RopeJointBuilder3::RopeJointBuilder3(Float) -> Self
 pub fn RopeJointBuilder3::build(Self) -> RopeJoint
 pub fn RopeJointBuilder3::local_anchor1(Self, @core.Vec3) -> Self
 pub fn RopeJointBuilder3::local_anchor2(Self, @core.Vec3) -> Self
@@ -1878,9 +1836,8 @@ pub fn RopeJointBuilder3::softness(Self, SpringCoefficients) -> Self
 
 pub struct RopeJointSet3DReal {
   joints : Array[RopeJoint3DReal]
-
-  fn new() -> RopeJointSet3DReal
 }
+pub fn RopeJointSet3DReal::RopeJointSet3DReal() -> Self
 pub fn RopeJointSet3DReal::insert(Self, RigidBodyHandle, RigidBodyHandle, Float) -> Unit
 pub fn RopeJointSet3DReal::interaction_pairs(Self) -> Array[(RigidBodyHandle, RigidBodyHandle)]
 pub fn RopeJointSet3DReal::new() -> Self
@@ -1907,9 +1864,8 @@ pub struct SphericalJoint3DReal {
 
 pub struct SphericalJoint3DRealBuilder {
   inner : GenericJoint3DRealBuilder
-
-  fn new() -> SphericalJoint3DRealBuilder
 }
+pub fn SphericalJoint3DRealBuilder::SphericalJoint3DRealBuilder() -> Self
 pub fn SphericalJoint3DRealBuilder::build(Self) -> GenericJoint3DReal
 pub fn SphericalJoint3DRealBuilder::limits(Self, JointAxis3DReal, Float, Float) -> Self
 pub fn SphericalJoint3DRealBuilder::local_anchor1(Self, @core.Vec3) -> Self
@@ -1930,9 +1886,8 @@ pub struct SphericalMotor3DReal {
 pub struct SpringCoefficients {
   natural_frequency : Float
   damping_ratio : Float
-
-  fn new(Float, Float) -> SpringCoefficients
 }
+pub fn SpringCoefficients::SpringCoefficients(Float, Float) -> Self
 pub fn SpringCoefficients::angular_frequency(Self) -> Float
 pub fn SpringCoefficients::cfm_coeff(Self, Float) -> Float
 pub fn SpringCoefficients::cfm_factor(Self, Float) -> Float
@@ -1944,9 +1899,8 @@ pub fn SpringCoefficients::new(Float, Float) -> Self
 
 pub struct SpringJoint {
   mut data : GenericJoint
-
-  fn new(Float, Float, Float) -> SpringJoint
 }
+pub fn SpringJoint::SpringJoint(Float, Float, Float) -> Self
 pub fn SpringJoint::contacts_enabled(Self) -> Bool
 pub fn SpringJoint::data(Self) -> GenericJoint
 pub fn SpringJoint::local_anchor1(Self) -> @core.Vec2
@@ -1969,9 +1923,8 @@ pub struct SpringJoint3DReal {
 
 pub struct SpringJointBuilder {
   mut inner : SpringJoint
-
-  fn new(Float, Float, Float) -> SpringJointBuilder
 }
+pub fn SpringJointBuilder::SpringJointBuilder(Float, Float, Float) -> Self
 pub fn SpringJointBuilder::build(Self) -> SpringJoint
 pub fn SpringJointBuilder::contacts_enabled(Self, Bool) -> Self
 pub fn SpringJointBuilder::local_anchor1(Self, @core.Vec2) -> Self

--- a/dynamics/placeholders.mbt
+++ b/dynamics/placeholders.mbt
@@ -44,8 +44,11 @@ struct SleepCandidate {
 ///|
 pub struct ContactGraph {
   pairs : Array[(RigidBodyHandle, RigidBodyHandle)]
+}
 
-  fn new() -> ContactGraph
+///|
+pub fn ContactGraph::ContactGraph() -> ContactGraph {
+  ContactGraph::new()
 }
 
 ///|
@@ -112,8 +115,11 @@ pub struct IslandManager {
   body_island_generations : Array[Int]
   body_island_indices : Array[Int]
   body_state_generations : Array[Int]
+}
 
-  fn new() -> IslandManager
+///|
+pub fn IslandManager::IslandManager() -> IslandManager {
+  IslandManager::new()
 }
 
 ///|
@@ -1188,8 +1194,6 @@ pub fn ImpulseJointGraph::edges(
 pub struct ImpulseJointHandle {
   id : Int
   generation : Int
-
-  fn new(id : Int, generation : Int) -> ImpulseJointHandle
 }
 
 ///|
@@ -1236,8 +1240,11 @@ pub struct GenericJoint {
   mut contacts_enabled : Bool
   mut enabled : JointEnabled
   user_data : Int
+}
 
-  fn new(locked_axes : JointAxesMask) -> GenericJoint
+///|
+pub fn GenericJoint::GenericJoint(locked_axes : JointAxesMask) -> GenericJoint {
+  GenericJoint::new(locked_axes)
 }
 
 ///|

--- a/dynamics/placeholders.mbt
+++ b/dynamics/placeholders.mbt
@@ -2199,7 +2199,7 @@ pub fn ImpulseJointSet::new() -> ImpulseJointSet {
 fn ij_split_values(text : String, sep : String) -> Array[String] {
   let values : Array[String] = []
   for part in text.split(sep[:]) {
-    let value = part.to_string()
+    let value = part.to_owned()
     if value.length() > 0 {
       values.push(value)
     }
@@ -2691,19 +2691,19 @@ pub fn ImpulseJointSet::deserialize(data : String) -> ImpulseJointSet {
   let free_handles : Array[Int] = []
   let entries : Array[String] = []
   for part in data.split(";"[:]) {
-    let value = part.to_string()
+    let value = part.to_owned()
     if value.strip_prefix("len="[:]) is Some(raw_view) {
-      len = ij_parse_int_value(raw_view.to_string())
+      len = ij_parse_int_value(raw_view.to_owned())
     } else if value.strip_prefix("gens="[:]) is Some(raw_view) {
-      for item in ij_split_values(raw_view.to_string(), ",") {
+      for item in ij_split_values(raw_view.to_owned(), ",") {
         gens.push(ij_parse_int_value(item))
       }
     } else if value.strip_prefix("free="[:]) is Some(raw_view) {
-      for item in ij_split_values(raw_view.to_string(), ",") {
+      for item in ij_split_values(raw_view.to_owned(), ",") {
         free_handles.push(ij_parse_int_value(item))
       }
     } else if value.strip_prefix("joints="[:]) is Some(raw_view) {
-      for item in ij_split_values(raw_view.to_string(), "|") {
+      for item in ij_split_values(raw_view.to_owned(), "|") {
         entries.push(item)
       }
     }
@@ -2724,7 +2724,7 @@ pub fn ImpulseJointSet::deserialize(data : String) -> ImpulseJointSet {
   for i in 0..<entries.length() {
     let entry = entries[i]
     if entry.strip_prefix("J^"[:]) is Some(rest_view) {
-      let fields = ij_split_values(rest_view.to_string(), "^")
+      let fields = ij_split_values(rest_view.to_owned(), "^")
       let id = if fields.length() > 0 {
         ij_parse_int_value(fields[0])
       } else {

--- a/dynamics/prismatic_joint_builder3.mbt
+++ b/dynamics/prismatic_joint_builder3.mbt
@@ -21,8 +21,13 @@ pub struct PrismaticJointBuilder3 {
   axis : @core.Vec3
   local_anchor1_3 : @core.Vec3
   local_anchor2_3 : @core.Vec3
+}
 
-  fn new(axis : @core.Vec3) -> PrismaticJointBuilder3
+///|
+pub fn PrismaticJointBuilder3::PrismaticJointBuilder3(
+  axis : @core.Vec3,
+) -> PrismaticJointBuilder3 {
+  PrismaticJointBuilder3::new(axis)
 }
 
 ///|

--- a/dynamics/revolute_joint3.mbt
+++ b/dynamics/revolute_joint3.mbt
@@ -19,8 +19,11 @@ pub struct RevoluteJoint3 {
   axis : @core.Vec3
   local_frame1_rotation : @core.Quat
   local_frame2_rotation : @core.Quat
+}
 
-  fn new(axis : @core.Vec3) -> RevoluteJoint3
+///|
+pub fn RevoluteJoint3::RevoluteJoint3(axis : @core.Vec3) -> RevoluteJoint3 {
+  RevoluteJoint3::new(axis)
 }
 
 ///|

--- a/dynamics/revolute_joint_builder3.mbt
+++ b/dynamics/revolute_joint_builder3.mbt
@@ -19,8 +19,13 @@ pub struct RevoluteJointBuilder3 {
   axis : @core.Vec3
   local_anchor1_3 : @core.Vec3
   local_anchor2_3 : @core.Vec3
+}
 
-  fn new(axis : @core.Vec3) -> RevoluteJointBuilder3
+///|
+pub fn RevoluteJointBuilder3::RevoluteJointBuilder3(
+  axis : @core.Vec3,
+) -> RevoluteJointBuilder3 {
+  RevoluteJointBuilder3::new(axis)
 }
 
 ///|

--- a/dynamics/rigid_body.mbt
+++ b/dynamics/rigid_body.mbt
@@ -2411,7 +2411,7 @@ fn body_type_from_int(value : Int) -> RigidBodyType {
 fn split_values(text : String, sep : String) -> Array[String] {
   let values : Array[String] = []
   for part in text.split(sep[:]) {
-    let value = part.to_string()
+    let value = part.to_owned()
     if value.length() > 0 {
       values.push(value)
     }
@@ -2589,30 +2589,30 @@ pub fn RigidBodySet::deserialize(data : String) -> RigidBodySet {
   let free_list : Array[Int] = []
   let bodies : Array[RigidBody?] = []
   for part in data.split(";"[:]) {
-    let value = part.to_string()
+    let value = part.to_owned()
     if value.strip_prefix("len="[:]) is Some(raw_view) {
-      let raw = raw_view.to_string()
+      let raw = raw_view.to_owned()
       len = parse_int_value(raw)
     } else if value.strip_prefix("gens="[:]) is Some(raw_view) {
-      let raw = raw_view.to_string()
+      let raw = raw_view.to_owned()
       let items = split_values(raw, ",")
       for item in items {
         generations.push(parse_int_value(item))
       }
     } else if value.strip_prefix("free="[:]) is Some(raw_view) {
-      let raw = raw_view.to_string()
+      let raw = raw_view.to_owned()
       let items = split_values(raw, ",")
       for item in items {
         free_list.push(parse_int_value(item))
       }
     } else if value.strip_prefix("bodies="[:]) is Some(raw_view) {
-      let raw = raw_view.to_string()
+      let raw = raw_view.to_owned()
       let entries = split_values(raw, "|")
       for entry in entries {
         if entry == "N" {
           bodies.push(None)
         } else if entry.strip_prefix("B,"[:]) is Some(entry_view) {
-          let fields = split_values(entry_view.to_string(), ",")
+          let fields = split_values(entry_view.to_owned(), ",")
           let body_type = body_type_from_int(
             if fields.length() > 0 {
               parse_int_value(fields[0])

--- a/dynamics/rigid_body.mbt
+++ b/dynamics/rigid_body.mbt
@@ -16,8 +16,6 @@
 pub struct RigidBodyHandle {
   id : Int
   generation : Int
-
-  fn new(id : Int, generation : Int) -> RigidBodyHandle
 }
 
 ///|
@@ -167,8 +165,13 @@ pub fn RigidBodyChanges::dominance() -> Int {
 ///|
 pub struct RigidBodyDominance {
   mut group : Int
+}
 
-  fn new(group : Int) -> RigidBodyDominance
+///|
+pub fn RigidBodyDominance::RigidBodyDominance(
+  group : Int,
+) -> RigidBodyDominance {
+  RigidBodyDominance::new(group)
 }
 
 ///|
@@ -222,11 +225,14 @@ pub type BodyStatus = RigidBodyType
 pub struct RigidBodyPosition {
   mut position : @core.Isometry2
   mut next_position : @core.Isometry2
+}
 
-  fn new(
-    position : @core.Isometry2,
-    next_position : @core.Isometry2,
-  ) -> RigidBodyPosition
+///|
+pub fn RigidBodyPosition::RigidBodyPosition(
+  position : @core.Isometry2,
+  next_position : @core.Isometry2,
+) -> RigidBodyPosition {
+  RigidBodyPosition::new(position, next_position)
 }
 
 ///|
@@ -275,8 +281,14 @@ pub fn RigidBodyPosition::integrate_forces_and_velocities(
 pub struct RigidBodyVelocity {
   mut linvel : @core.Vec2
   mut angvel : @core.Real
+}
 
-  fn new(linvel : @core.Vec2, angvel : @core.Real) -> RigidBodyVelocity
+///|
+pub fn RigidBodyVelocity::RigidBodyVelocity(
+  linvel : @core.Vec2,
+  angvel : @core.Real,
+) -> RigidBodyVelocity {
+  RigidBodyVelocity::new(linvel, angvel)
 }
 
 ///|
@@ -1721,8 +1733,13 @@ pub struct RigidBodyBuilder {
   mut soft_ccd_prediction : @core.Real
   mut dominance_group : Int
   mut user_data : @core.UserData128
+}
 
-  fn new(body_type : RigidBodyType) -> RigidBodyBuilder
+///|
+pub fn RigidBodyBuilder::RigidBodyBuilder(
+  body_type : RigidBodyType,
+) -> RigidBodyBuilder {
+  RigidBodyBuilder::new(body_type)
 }
 
 ///|
@@ -2080,8 +2097,11 @@ pub struct RigidBodySet {
   free_list : Array[Int]
   modified_bodies : Array[RigidBodyHandle]
   pending_collider_position_updates : Array[(Int, Int, @core.Isometry2)]
+}
 
-  fn new() -> RigidBodySet
+///|
+pub fn RigidBodySet::RigidBodySet() -> RigidBodySet {
+  RigidBodySet::new()
 }
 
 ///|

--- a/dynamics/rigid_body3d.mbt
+++ b/dynamics/rigid_body3d.mbt
@@ -71,11 +71,14 @@ pub fn RigidBodyVelocity3D::integrate(
 pub struct RigidBodyPosition3D {
   position : @core.Isometry3
   next_position : @core.Isometry3
+}
 
-  fn new(
-    position : @core.Isometry3,
-    next_position : @core.Isometry3,
-  ) -> RigidBodyPosition3D
+///|
+pub fn RigidBodyPosition3D::RigidBodyPosition3D(
+  position : @core.Isometry3,
+  next_position : @core.Isometry3,
+) -> RigidBodyPosition3D {
+  RigidBodyPosition3D::new(position, next_position)
 }
 
 ///|
@@ -1336,8 +1339,11 @@ pub struct RigidBodySet3D {
   bodies : Array[RigidBody3D?]
   generations : Array[Int]
   free_list : Array[Int]
+}
 
-  fn new() -> RigidBodySet3D
+///|
+pub fn RigidBodySet3D::RigidBodySet3D() -> RigidBodySet3D {
+  RigidBodySet3D::new()
 }
 
 ///|

--- a/dynamics/rigid_body_colliders_pub_parity.mbt
+++ b/dynamics/rigid_body_colliders_pub_parity.mbt
@@ -19,8 +19,11 @@
 /// independent from `collision::ColliderHandle` while preserving full handle identity.
 pub struct RigidBodyColliders {
   mut colliders : Array[(Int, Int)]
+}
 
-  fn new() -> RigidBodyColliders
+///|
+pub fn RigidBodyColliders::RigidBodyColliders() -> RigidBodyColliders {
+  RigidBodyColliders::new()
 }
 
 ///|

--- a/dynamics/rigid_body_components3.mbt
+++ b/dynamics/rigid_body_components3.mbt
@@ -23,11 +23,14 @@ pub struct PdErrors3 {
 pub struct RigidBodyPosition3 {
   position : @core.Isometry3
   next_position : @core.Isometry3
+}
 
-  fn new(
-    position : @core.Isometry3,
-    next_position : @core.Isometry3,
-  ) -> RigidBodyPosition3
+///|
+pub fn RigidBodyPosition3::RigidBodyPosition3(
+  position : @core.Isometry3,
+  next_position : @core.Isometry3,
+) -> RigidBodyPosition3 {
+  RigidBodyPosition3::new(position, next_position)
 }
 
 ///|

--- a/dynamics/rigid_body_set_pub_parity.mbt
+++ b/dynamics/rigid_body_set_pub_parity.mbt
@@ -19,8 +19,14 @@
 pub struct BodyPair {
   body1 : RigidBodyHandle
   body2 : RigidBodyHandle
+}
 
-  fn new(body1 : RigidBodyHandle, body2 : RigidBodyHandle) -> BodyPair
+///|
+pub fn BodyPair::BodyPair(
+  body1 : RigidBodyHandle,
+  body2 : RigidBodyHandle,
+) -> BodyPair {
+  BodyPair::new(body1, body2)
 }
 
 ///|

--- a/dynamics/rope_joint3d_real.mbt
+++ b/dynamics/rope_joint3d_real.mbt
@@ -27,8 +27,11 @@ pub struct RopeJoint3DReal {
 ///|
 pub struct RopeJointSet3DReal {
   joints : Array[RopeJoint3DReal]
+}
 
-  fn new() -> RopeJointSet3DReal
+///|
+pub fn RopeJointSet3DReal::RopeJointSet3DReal() -> RopeJointSet3DReal {
+  RopeJointSet3DReal::new()
 }
 
 ///|

--- a/dynamics/rope_joint_builder3.mbt
+++ b/dynamics/rope_joint_builder3.mbt
@@ -20,8 +20,13 @@ pub struct RopeJointBuilder3 {
   inner : RopeJointBuilder
   local_anchor1_3 : @core.Vec3
   local_anchor2_3 : @core.Vec3
+}
 
-  fn new(max_length : @core.Real) -> RopeJointBuilder3
+///|
+pub fn RopeJointBuilder3::RopeJointBuilder3(
+  max_length : @core.Real,
+) -> RopeJointBuilder3 {
+  RopeJointBuilder3::new(max_length)
 }
 
 ///|

--- a/dynamics/sets3.mbt
+++ b/dynamics/sets3.mbt
@@ -16,8 +16,11 @@
 /// 3D-flavored island manager.
 pub struct IslandManager3 {
   inner : IslandManager
+}
 
-  fn new() -> IslandManager3
+///|
+pub fn IslandManager3::IslandManager3() -> IslandManager3 {
+  IslandManager3::new()
 }
 
 ///|
@@ -322,8 +325,11 @@ pub fn IslandManager3::update_islands(
 /// 3D-flavored rigid-body set.
 pub struct RigidBodySet3 {
   inner : RigidBodySet
+}
 
-  fn new() -> RigidBodySet3
+///|
+pub fn RigidBodySet3::RigidBodySet3() -> RigidBodySet3 {
+  RigidBodySet3::new()
 }
 
 ///|

--- a/dynamics/spring_joint.mbt
+++ b/dynamics/spring_joint.mbt
@@ -19,12 +19,15 @@
 /// (capability-wise) for default features.
 pub struct SpringJoint {
   mut data : GenericJoint
+}
 
-  fn new(
-    rest_length : @core.Real,
-    stiffness : @core.Real,
-    damping : @core.Real,
-  ) -> SpringJoint
+///|
+pub fn SpringJoint::SpringJoint(
+  rest_length : @core.Real,
+  stiffness : @core.Real,
+  damping : @core.Real,
+) -> SpringJoint {
+  SpringJoint::new(rest_length, stiffness, damping)
 }
 
 ///|
@@ -104,12 +107,15 @@ pub fn SpringJoint::set_spring_model(
 ///|
 pub struct SpringJointBuilder {
   mut inner : SpringJoint
+}
 
-  fn new(
-    rest_length : @core.Real,
-    stiffness : @core.Real,
-    damping : @core.Real,
-  ) -> SpringJointBuilder
+///|
+pub fn SpringJointBuilder::SpringJointBuilder(
+  rest_length : @core.Real,
+  stiffness : @core.Real,
+  damping : @core.Real,
+) -> SpringJointBuilder {
+  SpringJointBuilder::new(rest_length, stiffness, damping)
 }
 
 ///|

--- a/pipeline/collision_pipeline3.mbt
+++ b/pipeline/collision_pipeline3.mbt
@@ -19,8 +19,11 @@
 /// rapier-reference dim3 unit tests.
 pub struct CollisionPipeline3 {
   inner : CollisionPipeline
+}
 
-  fn new() -> CollisionPipeline3
+///|
+pub fn CollisionPipeline3::CollisionPipeline3() -> CollisionPipeline3 {
+  CollisionPipeline3::new()
 }
 
 ///|

--- a/pipeline/contact_solver3d.mbt
+++ b/pipeline/contact_solver3d.mbt
@@ -47,8 +47,11 @@ pub struct ContactSolverCache3D {
     (Int, Int, Int, Int),
     Array[(@core.Vec3, @core.Vec3, ContactImpulse3D)],
   ]
+}
 
-  fn new() -> ContactSolverCache3D
+///|
+pub fn ContactSolverCache3D::ContactSolverCache3D() -> ContactSolverCache3D {
+  ContactSolverCache3D::new()
 }
 
 ///|

--- a/pipeline/contact_solver3d.mbt
+++ b/pipeline/contact_solver3d.mbt
@@ -56,7 +56,7 @@ pub fn ContactSolverCache3D::ContactSolverCache3D() -> ContactSolverCache3D {
 
 ///|
 pub fn ContactSolverCache3D::new() -> ContactSolverCache3D {
-  { entries: @hashmap.new() }
+  { entries: @hashmap.HashMap([]) }
 }
 
 ///|
@@ -1238,8 +1238,10 @@ pub fn solve_contacts_3d(
   physics_hooks : PhysicsHooks3D?,
   event_handler : EventHandler3D?,
 ) -> Unit {
-  let twist_cache_in : @hashmap.HashMap[(Int, Int, Int, Int), @core.Real] = @hashmap.new()
-  let twist_cache_out : @hashmap.HashMap[(Int, Int, Int, Int), @core.Real] = @hashmap.new()
+  let twist_cache_in : @hashmap.HashMap[(Int, Int, Int, Int), @core.Real] = @hashmap.HashMap([],
+  )
+  let twist_cache_out : @hashmap.HashMap[(Int, Int, Int, Int), @core.Real] = @hashmap.HashMap([],
+  )
   solve_contacts_3d_impl(
     parameters,
     bodies,

--- a/pipeline/debug_render_pipeline.mbt
+++ b/pipeline/debug_render_pipeline.mbt
@@ -18,13 +18,16 @@ pub struct DebugColor {
   s : @core.Real
   l : @core.Real
   a : @core.Real
+}
 
-  fn new(
-    h : @core.Real,
-    s : @core.Real,
-    l : @core.Real,
-    a : @core.Real,
-  ) -> DebugColor
+///|
+pub fn DebugColor::DebugColor(
+  h : @core.Real,
+  s : @core.Real,
+  l : @core.Real,
+  a : @core.Real,
+) -> DebugColor {
+  DebugColor::new(h, s, l, a)
 }
 
 ///|
@@ -211,8 +214,11 @@ pub struct DebugRenderLine {
 ///|
 pub struct DebugRenderBackend {
   lines : Array[DebugRenderLine]
+}
 
-  fn new() -> DebugRenderBackend
+///|
+pub fn DebugRenderBackend::DebugRenderBackend() -> DebugRenderBackend {
+  DebugRenderBackend::new()
 }
 
 ///|
@@ -368,11 +374,14 @@ pub fn DebugRenderBackend::serialize_lines(self : DebugRenderBackend) -> String 
 pub struct DebugRenderPipeline {
   style : DebugRenderStyle
   mode : DebugRenderMode
+}
 
-  fn new(
-    style : DebugRenderStyle,
-    mode : DebugRenderMode,
-  ) -> DebugRenderPipeline
+///|
+pub fn DebugRenderPipeline::DebugRenderPipeline(
+  style : DebugRenderStyle,
+  mode : DebugRenderMode,
+) -> DebugRenderPipeline {
+  DebugRenderPipeline::new(style, mode)
 }
 
 ///|

--- a/pipeline/event_handler.mbt
+++ b/pipeline/event_handler.mbt
@@ -33,8 +33,11 @@ pub struct EventHandler {
     @collision.ColliderSet,
     @collision.ContactForceEvent,
   ) -> Unit)?
+}
 
-  fn new() -> EventHandler
+///|
+pub fn EventHandler::EventHandler() -> EventHandler {
+  EventHandler::new()
 }
 
 ///|
@@ -192,8 +195,11 @@ pub fn EventHandler::take_contact_force_events(
 ///|
 pub struct ChannelEventCollector {
   handler : EventHandler
+}
 
-  fn new() -> ChannelEventCollector
+///|
+pub fn ChannelEventCollector::ChannelEventCollector() -> ChannelEventCollector {
+  ChannelEventCollector::new()
 }
 
 ///|

--- a/pipeline/event_handler3d.mbt
+++ b/pipeline/event_handler3d.mbt
@@ -17,8 +17,11 @@ pub struct EventHandler3D {
   collision_events : Array[@collision.CollisionEvent3D]
   intersection_events : Array[@collision.IntersectionEvent3D]
   contact_force_events : Array[@collision.ContactForceEvent3D]
+}
 
-  fn new() -> EventHandler3D
+///|
+pub fn EventHandler3D::EventHandler3D() -> EventHandler3D {
+  EventHandler3D::new()
 }
 
 ///|

--- a/pipeline/physics_hooks.mbt
+++ b/pipeline/physics_hooks.mbt
@@ -20,15 +20,20 @@ pub struct PairFilterContext {
   collider2 : @collision.ColliderHandle
   rigid_body1 : @dynamics.RigidBodyHandle?
   rigid_body2 : @dynamics.RigidBodyHandle?
+}
 
-  fn new(
-    bodies : @dynamics.RigidBodySet,
-    colliders : @collision.ColliderSet,
-    collider1 : @collision.ColliderHandle,
-    collider2 : @collision.ColliderHandle,
-    rigid_body1 : @dynamics.RigidBodyHandle?,
-    rigid_body2 : @dynamics.RigidBodyHandle?,
-  ) -> PairFilterContext
+///|
+pub fn PairFilterContext::PairFilterContext(
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
+  collider1 : @collision.ColliderHandle,
+  collider2 : @collision.ColliderHandle,
+  rigid_body1 : @dynamics.RigidBodyHandle?,
+  rigid_body2 : @dynamics.RigidBodyHandle?,
+) -> PairFilterContext {
+  PairFilterContext::new(
+    bodies, colliders, collider1, collider2, rigid_body1, rigid_body2,
+  )
 }
 
 ///|
@@ -55,19 +60,25 @@ pub struct ContactModificationContext {
   solver_contacts : Array[@collision.SolverContact]
   mut normal : @core.Vec2
   mut user_data : Int
+}
 
-  fn new(
-    bodies : @dynamics.RigidBodySet,
-    colliders : @collision.ColliderSet,
-    collider1 : @collision.ColliderHandle,
-    collider2 : @collision.ColliderHandle,
-    rigid_body1 : @dynamics.RigidBodyHandle?,
-    rigid_body2 : @dynamics.RigidBodyHandle?,
-    manifold : @collision.ContactManifold,
-    solver_contacts : Array[@collision.SolverContact],
-    normal : @core.Vec2,
-    user_data : Int,
-  ) -> ContactModificationContext
+///|
+pub fn ContactModificationContext::ContactModificationContext(
+  bodies : @dynamics.RigidBodySet,
+  colliders : @collision.ColliderSet,
+  collider1 : @collision.ColliderHandle,
+  collider2 : @collision.ColliderHandle,
+  rigid_body1 : @dynamics.RigidBodyHandle?,
+  rigid_body2 : @dynamics.RigidBodyHandle?,
+  manifold : @collision.ContactManifold,
+  solver_contacts : Array[@collision.SolverContact],
+  normal : @core.Vec2,
+  user_data : Int,
+) -> ContactModificationContext {
+  ContactModificationContext::new(
+    bodies, colliders, collider1, collider2, rigid_body1, rigid_body2, manifold,
+    solver_contacts, normal, user_data,
+  )
 }
 
 ///|
@@ -203,8 +214,11 @@ pub struct PhysicsHooks {
     Array[@collision.SolverContact],
     @collision.SolverFlags,
   ) -> @collision.SolverFlags)?
+}
 
-  fn new() -> PhysicsHooks
+///|
+pub fn PhysicsHooks::PhysicsHooks() -> PhysicsHooks {
+  PhysicsHooks::new()
 }
 
 ///|

--- a/pipeline/physics_hooks3d.mbt
+++ b/pipeline/physics_hooks3d.mbt
@@ -33,8 +33,11 @@ pub struct PhysicsHooks3D {
     @collision.ColliderHandle3D,
     @core.Vec3,
   ) -> (Bool, @core.Vec3?))?
+}
 
-  fn new() -> PhysicsHooks3D
+///|
+pub fn PhysicsHooks3D::PhysicsHooks3D() -> PhysicsHooks3D {
+  PhysicsHooks3D::new()
 }
 
 ///|

--- a/pipeline/physics_pipeline.mbt
+++ b/pipeline/physics_pipeline.mbt
@@ -27,8 +27,11 @@ pub struct PhysicsPipeline {
   ]
   contact_solver_cache : Array[ContactImpulseCacheEntry]
   counters : @counters.Counters
+}
 
-  fn new() -> PhysicsPipeline
+///|
+pub fn PhysicsPipeline::PhysicsPipeline() -> PhysicsPipeline {
+  PhysicsPipeline::new()
 }
 
 ///|

--- a/pipeline/physics_pipeline3.mbt
+++ b/pipeline/physics_pipeline3.mbt
@@ -19,8 +19,11 @@
 /// shared solver core.
 pub struct PhysicsPipeline3 {
   inner : PhysicsPipeline
+}
 
-  fn new() -> PhysicsPipeline3
+///|
+pub fn PhysicsPipeline3::PhysicsPipeline3() -> PhysicsPipeline3 {
+  PhysicsPipeline3::new()
 }
 
 ///|

--- a/pipeline/physics_pipeline3d.mbt
+++ b/pipeline/physics_pipeline3d.mbt
@@ -19,8 +19,11 @@
 /// incremental 3D backend implementation (`PhysicsPipeline3DReal`).
 pub struct PhysicsPipeline3D {
   inner : PhysicsPipeline3DReal
+}
 
-  fn new() -> PhysicsPipeline3D
+///|
+pub fn PhysicsPipeline3D::PhysicsPipeline3D() -> PhysicsPipeline3D {
+  PhysicsPipeline3D::new()
 }
 
 ///|

--- a/pipeline/physics_pipeline3d_real.mbt
+++ b/pipeline/physics_pipeline3d_real.mbt
@@ -42,7 +42,7 @@ pub fn PhysicsPipeline3DReal::PhysicsPipeline3DReal() -> PhysicsPipeline3DReal {
 pub fn PhysicsPipeline3DReal::new() -> PhysicsPipeline3DReal {
   {
     contact_cache: ContactSolverCache3D::new(),
-    contact_twist_cache: @hashmap.new(),
+    contact_twist_cache: @hashmap.HashMap([]),
     sensor_pairs: [],
     contact_pairs: [],
     intersection_pairs: [],
@@ -291,7 +291,8 @@ fn clamp_fast_ccd_body_motions_3d_real(
     bodies,
     colliders,
   )
-  let best_toi_by_body : @hashmap.HashMap[(Int, Int), @core.Real] = @hashmap.new()
+  let best_toi_by_body : @hashmap.HashMap[(Int, Int), @core.Real] = @hashmap.HashMap([],
+  )
   let collider_handles = colliders.all_handles()
   for i in 0..<collider_handles.length() {
     let ch = collider_handles[i]
@@ -725,7 +726,8 @@ fn filter_broad_phase_pairs_3d(
     disabled_body_pairs.append(multibody.disabled_contact_pairs()[:])
   }
   if disabled_body_pairs.length() > 0 {
-    let out : @hashmap.HashMap[(Int, Int, Int, Int), Bool] = @hashmap.new(
+    let out : @hashmap.HashMap[(Int, Int, Int, Int), Bool] = @hashmap.HashMap(
+      [],
       capacity=disabled_body_pairs.length() * 2,
     )
     for p in disabled_body_pairs {
@@ -785,7 +787,8 @@ fn collect_solver_interactions_3d_real(
   let interactions : Array[
     (@dynamics.RigidBodyHandle, @dynamics.RigidBodyHandle),
   ] = []
-  let interaction_keys : @hashmap.HashMap[(Int, Int, Int, Int), Bool] = @hashmap.new()
+  let interaction_keys : @hashmap.HashMap[(Int, Int, Int, Int), Bool] = @hashmap.HashMap([],
+  )
   fn push_unique_interaction(
     interactions : Array[(@dynamics.RigidBodyHandle, @dynamics.RigidBodyHandle)],
     interaction_keys : @hashmap.HashMap[(Int, Int, Int, Int), Bool],
@@ -1486,7 +1489,8 @@ fn PhysicsPipeline3DReal::step_impl_one(
   let mut twist_cache_in = self.contact_twist_cache
   for pass in 0..<coupling_passes {
     let cache_out = ContactSolverCache3D::new()
-    let twist_cache_out : @hashmap.HashMap[(Int, Int, Int, Int), @core.Real] = @hashmap.new()
+    let twist_cache_out : @hashmap.HashMap[(Int, Int, Int, Int), @core.Real] = @hashmap.HashMap([],
+    )
     let pass_events = if pass + 1 == coupling_passes { events } else { None }
     if active_island_ids.length() > 0 {
       for island_idx in 0..<active_island_ids.length() {

--- a/pipeline/physics_pipeline3d_real.mbt
+++ b/pipeline/physics_pipeline3d_real.mbt
@@ -31,8 +31,11 @@ pub struct PhysicsPipeline3DReal {
   intersection_pairs : Array[
     (@collision.ColliderHandle3D, @collision.ColliderHandle3D),
   ]
+}
 
-  fn new() -> PhysicsPipeline3DReal
+///|
+pub fn PhysicsPipeline3DReal::PhysicsPipeline3DReal() -> PhysicsPipeline3DReal {
+  PhysicsPipeline3DReal::new()
 }
 
 ///|

--- a/pipeline/pkg.generated.mbti
+++ b/pipeline/pkg.generated.mbti
@@ -32,9 +32,8 @@ pub fn solve_contacts_3d(@dynamics.IntegrationParameters, @dynamics.RigidBodySet
 // Types and methods
 pub struct ChannelEventCollector {
   handler : EventHandler
-
-  fn new() -> ChannelEventCollector
 }
+pub fn ChannelEventCollector::ChannelEventCollector() -> Self
 pub fn ChannelEventCollector::handle_collision_event(Self, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.CollisionEvent) -> Unit
 pub fn ChannelEventCollector::handle_contact_force_event(Self, Float, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.ContactForceEvent) -> Unit
 pub fn ChannelEventCollector::handle_intersection_event(Self, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.IntersectionEvent) -> Unit
@@ -50,9 +49,8 @@ pub fn CollisionPipeline::step(Self, Float, @dynamics.IslandManager, @collision.
 
 pub struct CollisionPipeline3 {
   inner : CollisionPipeline
-
-  fn new() -> CollisionPipeline3
 }
+pub fn CollisionPipeline3::CollisionPipeline3() -> Self
 pub fn CollisionPipeline3::new() -> Self
 pub fn CollisionPipeline3::step(Self, Float, @dynamics.IslandManager3, @collision.BroadPhaseBvh, @collision.NarrowPhase, @dynamics.RigidBodySet3, @collision.ColliderSet3, PhysicsHooks, EventHandler) -> Unit
 
@@ -84,9 +82,8 @@ pub struct ContactModificationContext {
   solver_contacts : Array[@collision.SolverContact]
   mut normal : @core.Vec2
   mut user_data : Int
-
-  fn new(@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @dynamics.RigidBodyHandle?, @dynamics.RigidBodyHandle?, @collision.ContactManifold, Array[@collision.SolverContact], @core.Vec2, Int) -> ContactModificationContext
 }
+pub fn ContactModificationContext::ContactModificationContext(@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @dynamics.RigidBodyHandle?, @dynamics.RigidBodyHandle?, @collision.ContactManifold, Array[@collision.SolverContact], @core.Vec2, Int) -> Self
 pub fn ContactModificationContext::new(@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @dynamics.RigidBodyHandle?, @dynamics.RigidBodyHandle?, @collision.ContactManifold, Array[@collision.SolverContact], @core.Vec2, Int) -> Self
 pub fn ContactModificationContext::normal(Self) -> @core.Vec2
 pub fn ContactModificationContext::set_normal(Self, @core.Vec2) -> Unit
@@ -95,9 +92,8 @@ pub fn ContactModificationContext::update_as_oneway_platform(Self, @core.Vec2, F
 
 pub struct ContactSolverCache3D {
   entries : @hashmap.HashMap[(Int, Int, Int, Int), Array[(@core.Vec3, @core.Vec3, ContactImpulse3D)]]
-
-  fn new() -> ContactSolverCache3D
 }
+pub fn ContactSolverCache3D::ContactSolverCache3D() -> Self
 pub fn ContactSolverCache3D::clear(Self) -> Unit
 pub fn ContactSolverCache3D::new() -> Self
 
@@ -106,16 +102,14 @@ pub struct DebugColor {
   s : Float
   l : Float
   a : Float
-
-  fn new(Float, Float, Float, Float) -> DebugColor
 }
+pub fn DebugColor::DebugColor(Float, Float, Float, Float) -> Self
 pub fn DebugColor::new(Float, Float, Float, Float) -> Self
 
 pub struct DebugRenderBackend {
   lines : Array[DebugRenderLine]
-
-  fn new() -> DebugRenderBackend
 }
+pub fn DebugRenderBackend::DebugRenderBackend() -> Self
 pub fn DebugRenderBackend::draw_line(Self, DebugRenderObject, @core.Vec2, @core.Vec2, DebugColor) -> Unit
 pub fn DebugRenderBackend::draw_line_strip(Self, DebugRenderObject, Array[@core.Vec2], DebugColor, Bool) -> Unit
 pub fn DebugRenderBackend::draw_polyline(Self, DebugRenderObject, Array[@core.Vec2], DebugColor, Bool) -> Unit
@@ -161,9 +155,8 @@ pub(all) enum DebugRenderObject {
 pub struct DebugRenderPipeline {
   style : DebugRenderStyle
   mode : DebugRenderMode
-
-  fn new(DebugRenderStyle, DebugRenderMode) -> DebugRenderPipeline
 }
+pub fn DebugRenderPipeline::DebugRenderPipeline(DebugRenderStyle, DebugRenderMode) -> Self
 pub fn DebugRenderPipeline::default() -> Self
 pub fn DebugRenderPipeline::new(DebugRenderStyle, DebugRenderMode) -> Self
 pub fn DebugRenderPipeline::render(Self, DebugRenderBackend, @dynamics.RigidBodySet, @collision.ColliderSet, @dynamics.ImpulseJointSet, @dynamics.MultibodyJointSet, @collision.NarrowPhase) -> Unit
@@ -201,9 +194,8 @@ pub struct EventHandler {
   mut intersection_callback : ((@dynamics.RigidBodySet, @collision.ColliderSet, @collision.IntersectionEvent) -> Unit)?
   contact_force_events : Array[@collision.ContactForceEvent]
   mut contact_force_callback : ((Float, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.ContactForceEvent) -> Unit)?
-
-  fn new() -> EventHandler
 }
+pub fn EventHandler::EventHandler() -> Self
 pub fn EventHandler::handle_collision_event(Self, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.CollisionEvent) -> Unit
 pub fn EventHandler::handle_contact_force_event(Self, Float, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.ContactForceEvent) -> Unit
 pub fn EventHandler::handle_intersection_event(Self, @dynamics.RigidBodySet, @collision.ColliderSet, @collision.IntersectionEvent) -> Unit
@@ -222,9 +214,8 @@ pub struct EventHandler3D {
   collision_events : Array[@collision.CollisionEvent3D]
   intersection_events : Array[@collision.IntersectionEvent3D]
   contact_force_events : Array[@collision.ContactForceEvent3D]
-
-  fn new() -> EventHandler3D
 }
+pub fn EventHandler3D::EventHandler3D() -> Self
 pub fn EventHandler3D::new() -> Self
 pub fn EventHandler3D::push_collision_event(Self, @collision.CollisionEvent3D) -> Unit
 pub fn EventHandler3D::push_contact_force_event(Self, @collision.ContactForceEvent3D) -> Unit
@@ -240,9 +231,8 @@ pub struct PairFilterContext {
   collider2 : @collision.ColliderHandle
   rigid_body1 : @dynamics.RigidBodyHandle?
   rigid_body2 : @dynamics.RigidBodyHandle?
-
-  fn new(@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @dynamics.RigidBodyHandle?, @dynamics.RigidBodyHandle?) -> PairFilterContext
 }
+pub fn PairFilterContext::PairFilterContext(@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @dynamics.RigidBodyHandle?, @dynamics.RigidBodyHandle?) -> Self
 pub fn PairFilterContext::new(@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @dynamics.RigidBodyHandle?, @dynamics.RigidBodyHandle?) -> Self
 
 pub struct PhysicsHooks {
@@ -250,9 +240,8 @@ pub struct PhysicsHooks {
   mut filter_intersection_pair : ((@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle) -> Bool)?
   mut modify_solver_contacts : ((@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @collision.ContactManifold) -> (Bool, @core.Vec2))?
   mut modify_solver_contacts_with_solver_contacts : ((@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @collision.ContactManifold, Array[@collision.SolverContact], @collision.SolverFlags) -> @collision.SolverFlags)?
-
-  fn new() -> PhysicsHooks
 }
+pub fn PhysicsHooks::PhysicsHooks() -> Self
 pub fn PhysicsHooks::filter_contact_pair(Self, (@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle) -> Bool) -> Self
 pub fn PhysicsHooks::filter_contact_pair_with_user_data(Self, (@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle, @core.UserData128, @core.UserData128, @dynamics.RigidBodyHandle?, @dynamics.RigidBodyHandle?, @core.UserData128?, @core.UserData128?) -> Bool) -> Self
 pub fn PhysicsHooks::filter_intersection_pair(Self, (@dynamics.RigidBodySet, @collision.ColliderSet, @collision.ColliderHandle, @collision.ColliderHandle) -> Bool) -> Self
@@ -267,9 +256,8 @@ pub struct PhysicsHooks3D {
   mut filter_contact_pair : ((@dynamics.RigidBodySet3D, @collision.ColliderSet3D, @collision.ColliderHandle3D, @collision.ColliderHandle3D) -> Bool)?
   mut filter_intersection_pair : ((@dynamics.RigidBodySet3D, @collision.ColliderSet3D, @collision.ColliderHandle3D, @collision.ColliderHandle3D) -> Bool)?
   mut modify_solver_contacts : ((@dynamics.RigidBodySet3D, @collision.ColliderSet3D, @collision.ColliderHandle3D, @collision.ColliderHandle3D, @core.Vec3) -> (Bool, @core.Vec3?))?
-
-  fn new() -> PhysicsHooks3D
 }
+pub fn PhysicsHooks3D::PhysicsHooks3D() -> Self
 pub fn PhysicsHooks3D::filter_contact_pair(Self, (@dynamics.RigidBodySet3D, @collision.ColliderSet3D, @collision.ColliderHandle3D, @collision.ColliderHandle3D) -> Bool) -> Self
 pub fn PhysicsHooks3D::filter_contact_pair_with_user_data(Self, (@dynamics.RigidBodySet3D, @collision.ColliderSet3D, @collision.ColliderHandle3D, @collision.ColliderHandle3D, @core.UserData128, @core.UserData128, @dynamics.RigidBodyHandle?, @dynamics.RigidBodyHandle?, @core.UserData128?, @core.UserData128?) -> Bool) -> Self
 pub fn PhysicsHooks3D::filter_intersection_pair(Self, (@dynamics.RigidBodySet3D, @collision.ColliderSet3D, @collision.ColliderHandle3D, @collision.ColliderHandle3D) -> Bool) -> Self
@@ -283,25 +271,22 @@ pub struct PhysicsPipeline {
   prev_intersections : Array[(@collision.ColliderHandle, @collision.ColliderHandle, Bool)]
   contact_solver_cache : Array[ContactImpulseCacheEntry]
   counters : @counters.Counters
-
-  fn new() -> PhysicsPipeline
 }
+pub fn PhysicsPipeline::PhysicsPipeline() -> Self
 pub fn PhysicsPipeline::new() -> Self
 pub fn PhysicsPipeline::step(Self, @core.Vec2, @dynamics.IntegrationParameters, @dynamics.IslandManager, @collision.BroadPhaseBvh, @collision.NarrowPhase, @dynamics.RigidBodySet, @collision.ColliderSet, @dynamics.ImpulseJointSet, @dynamics.MultibodyJointSet, @dynamics_ccd.CCDSolver, PhysicsHooks, EventHandler) -> Unit
 
 pub struct PhysicsPipeline3 {
   inner : PhysicsPipeline
-
-  fn new() -> PhysicsPipeline3
 }
+pub fn PhysicsPipeline3::PhysicsPipeline3() -> Self
 pub fn PhysicsPipeline3::new() -> Self
 pub fn PhysicsPipeline3::step(Self, @core.Vec3, @dynamics.IntegrationParameters, @dynamics.IslandManager3, @collision.BroadPhaseBvh, @collision.NarrowPhase, @dynamics.RigidBodySet3, @collision.ColliderSet3, @dynamics.ImpulseJointSet3, @dynamics.MultibodyJointSet3, @dynamics_ccd.CCDSolver, PhysicsHooks, EventHandler) -> Unit
 
 pub struct PhysicsPipeline3D {
   inner : PhysicsPipeline3DReal
-
-  fn new() -> PhysicsPipeline3D
 }
+pub fn PhysicsPipeline3D::PhysicsPipeline3D() -> Self
 pub fn PhysicsPipeline3D::new() -> Self
 pub fn PhysicsPipeline3D::step(Self, @core.Vec3, @dynamics.IntegrationParameters, @dynamics.IslandManager3D, @collision.BroadPhase3D, @collision.NarrowPhase3D, @dynamics.RigidBodySet3D, @collision.ColliderSet3D) -> Unit
 pub fn PhysicsPipeline3D::step_integration_only(Self, @core.Vec3, @dynamics.IntegrationParameters, @dynamics.RigidBodySet3D) -> Unit
@@ -325,9 +310,8 @@ pub struct PhysicsPipeline3DReal {
   contact_pairs : Array[(@collision.ColliderHandle3D, @collision.ColliderHandle3D)]
   intersection_pairs : Array[(@collision.ColliderHandle3D, @collision.ColliderHandle3D)]
   // private fields
-
-  fn new() -> PhysicsPipeline3DReal
 }
+pub fn PhysicsPipeline3DReal::PhysicsPipeline3DReal() -> Self
 pub fn PhysicsPipeline3DReal::new() -> Self
 pub fn PhysicsPipeline3DReal::step(Self, @core.Vec3, @dynamics.IntegrationParameters, @dynamics.IslandManager3D, @collision.BroadPhase3D, @collision.NarrowPhase3D, @dynamics.RigidBodySet3D, @collision.ColliderSet3D) -> Unit
 pub fn PhysicsPipeline3DReal::step_with_events(Self, @core.Vec3, @dynamics.IntegrationParameters, @dynamics.IslandManager3D, @collision.BroadPhase3D, @collision.NarrowPhase3D, @dynamics.RigidBodySet3D, @collision.ColliderSet3D, EventHandler3D) -> Unit

--- a/rapier_full/t12_urdf_assets_test.mbt
+++ b/rapier_full/t12_urdf_assets_test.mbt
@@ -2155,7 +2155,8 @@ pub fn t12_mesh_bounds_map() -> @hashmap.HashMap[
   String,
   (@core.Vec3, @core.Vec3),
 ] {
-  let m : @hashmap.HashMap[String, (@core.Vec3, @core.Vec3)] = @hashmap.new(
+  let m : @hashmap.HashMap[String, (@core.Vec3, @core.Vec3)] = @hashmap.HashMap(
+    [],
     capacity=37,
   )
   m.set(

--- a/rapier_full_parity/t12_urdf_assets_test.mbt
+++ b/rapier_full_parity/t12_urdf_assets_test.mbt
@@ -2155,7 +2155,8 @@ pub fn t12_mesh_bounds_map() -> @hashmap.HashMap[
   String,
   (@core.Vec3, @core.Vec3),
 ] {
-  let m : @hashmap.HashMap[String, (@core.Vec3, @core.Vec3)] = @hashmap.new(
+  let m : @hashmap.HashMap[String, (@core.Vec3, @core.Vec3)] = @hashmap.HashMap(
+    [],
     capacity=37,
   )
   m.set(

--- a/tools/run_optional_feature_parity_gate.sh
+++ b/tools/run_optional_feature_parity_gate.sh
@@ -83,10 +83,10 @@ run_audit_profile \
   "rapier2d_f64" "rapier3d_f64"
 
 echo "[optional-gate] run targeted semantic parity tests"
-moon test --frozen -p pipeline -f feature_flags_test.mbt
-moon test --frozen -p pipeline -f debug_render_pipeline_test.mbt
-moon test --frozen -p pipeline -f snapshot_roundtrip_test.mbt
-moon test --frozen -p counters -f counters_test.mbt
-moon test --frozen -p utils -f serde_test.mbt
+moon test --frozen pipeline/feature_flags_test.mbt
+moon test --frozen pipeline/debug_render_pipeline_test.mbt
+moon test --frozen pipeline/snapshot_roundtrip_test.mbt
+moon test --frozen counters/counters_test.mbt
+moon test --frozen utils/serde_test.mbt
 
 echo "[optional-gate] success"

--- a/tools/run_pub_parity_gate.sh
+++ b/tools/run_pub_parity_gate.sh
@@ -57,7 +57,7 @@ run_nonempty_test() {
   local tmp
   local total
   tmp="$(mktemp)"
-  moon test --frozen -p Milky2018/moon_rapier/rapier_full_parity -f "$file" \
+  moon test --frozen "rapier_full_parity/$file" \
     2>&1 | tee "$tmp"
   total="$(awk -F'[:, ]+' '/^Total tests:/ { print $3 }' "$tmp" | tail -n1)"
   rm -f "$tmp"

--- a/urdf/urdf_loader3d_real.mbt
+++ b/urdf/urdf_loader3d_real.mbt
@@ -405,7 +405,7 @@ fn basename(path : String) -> String {
     path
   } else {
     // Safe: indices are within bounds.
-    path[last + 1:path.length()].to_string()
+    path[last + 1:path.length()].to_owned()
   }
 }
 

--- a/urdf/urdf_loader3d_real.mbt
+++ b/urdf/urdf_loader3d_real.mbt
@@ -334,7 +334,7 @@ fn xml_parse_tag(s : String, start : Int) -> (XmlTag?, Int) {
   if name == "" {
     return (None, start + 1)
   }
-  let attrs : @hashmap.HashMap[String, String] = @hashmap.new()
+  let attrs : @hashmap.HashMap[String, String] = @hashmap.HashMap([])
   j = xml_skip_ws(s, j)
   while j < s.length() {
     let c = Int::unsafe_to_char(s.code_unit_at(j).to_int())
@@ -710,19 +710,24 @@ pub fn UrdfRobot3DReal::insert_3d_real(
   joints : @dynamics.JointSet3DReal,
   base_transform : @core.Isometry3,
 ) -> Unit {
-  let link_to_body : @hashmap.HashMap[String, @dynamics.RigidBodyHandle] = @hashmap.new(
+  let link_to_body : @hashmap.HashMap[String, @dynamics.RigidBodyHandle] = @hashmap.HashMap(
+    [],
     capacity=self.links.length(),
   )
-  let link_pose_urdf : @hashmap.HashMap[String, @core.Isometry3] = @hashmap.new(
+  let link_pose_urdf : @hashmap.HashMap[String, @core.Isometry3] = @hashmap.HashMap(
+    [],
     capacity=self.links.length(),
   )
-  let link_visuals : @hashmap.HashMap[String, Array[UrdfVisual]] = @hashmap.new(
+  let link_visuals : @hashmap.HashMap[String, Array[UrdfVisual]] = @hashmap.HashMap(
+    [],
     capacity=self.links.length(),
   )
-  let link_collisions : @hashmap.HashMap[String, Array[UrdfVisual]] = @hashmap.new(
+  let link_collisions : @hashmap.HashMap[String, Array[UrdfVisual]] = @hashmap.HashMap(
+    [],
     capacity=self.links.length(),
   )
-  let link_inertials : @hashmap.HashMap[String, UrdfInertial3DReal?] = @hashmap.new(
+  let link_inertials : @hashmap.HashMap[String, UrdfInertial3DReal?] = @hashmap.HashMap(
+    [],
     capacity=self.links.length(),
   )
   for i in 0..<self.links.length() {
@@ -731,7 +736,8 @@ pub fn UrdfRobot3DReal::insert_3d_real(
     link_collisions.set(l.name, l.collisions)
     link_inertials.set(l.name, l.inertial)
   }
-  let children : @hashset.HashSet[String] = @hashset.new(
+  let children : @hashset.HashSet[String] = @hashset.HashSet(
+    [],
     capacity=self.joints.length(),
   )
   for j in self.joints {

--- a/utils/serde.mbt
+++ b/utils/serde.mbt
@@ -83,7 +83,7 @@ pub fn serialize_to_vec_tuple(target : HashMap) -> String {
 fn split_values(text : String, sep : String) -> Array[String] {
   let values : Array[String] = []
   for part in text.split(sep[:]) {
-    let value = part.to_string()
+    let value = part.to_owned()
     if value.length() > 0 {
       values.push(value)
     }
@@ -138,7 +138,7 @@ pub fn deserialize_from_vec_tuple(value : String) -> HashMap {
   let entries : Array[(Int, String)] = []
   if value.strip_prefix("{\"map\":["[:]) is Some(list_view) {
     if list_view.strip_suffix("]}"[:]) is Some(items_view) {
-      let items = items_view.to_string()
+      let items = items_view.to_owned()
       if items.length() > 0 {
         for part in items.split("],["[:]) {
           let mut entry_view = part
@@ -148,15 +148,15 @@ pub fn deserialize_from_vec_tuple(value : String) -> HashMap {
           if entry_view.strip_suffix("]"[:]) is Some(view) {
             entry_view = view
           }
-          let fields = split_values(entry_view.to_string(), ",")
+          let fields = split_values(entry_view.to_owned(), ",")
           if fields.length() >= 2 {
             let key = parse_int_value(fields[0])
             let mut raw_text = fields[1]
             if raw_text.strip_prefix("\""[:]) is Some(view) {
-              raw_text = view.to_string()
+              raw_text = view.to_owned()
             }
             if raw_text.strip_suffix("\""[:]) is Some(view) {
-              raw_text = view.to_string()
+              raw_text = view.to_owned()
             }
             let parsed = unescape_json_string(raw_text)
             entries.push((key, parsed))


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs and debug assertions as needed.

## Validation
- `moon check --target all`
- `moon fmt`

## Note
- Full test validation was attempted, but the large parity test did not finish in the local run.
